### PR TITLE
Fix/#25

### DIFF
--- a/src/components/community/post/CommentInput.tsx
+++ b/src/components/community/post/CommentInput.tsx
@@ -29,7 +29,7 @@ const CommentInput = ({ isOpen, currentIndex }: CommentInputProps) => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
         handleSend()
       }

--- a/src/components/community/post/PostComment.tsx
+++ b/src/components/community/post/PostComment.tsx
@@ -12,26 +12,29 @@ import { useTextArea } from '@/util/useTextArea'
 const PostComment = memo(() => {
   const { value, onChange, clear } = useTextArea('')
   const [anonymous, setAnonymous] = useState(false)
+  const [isKeyDown, setIsKeyDown] = useState(false)
   const { mutate: mutateComment } = usePostComment()
   const postAtomData = useAtomValue(postAtom)
 
   const handleSubmitClick = useCallback(() => {
     if (value.trim() === '') return alert('Please enter a comment')
-    mutateComment({ postId: postAtomData.id, content: value, isAnonymous: anonymous })
-  }, [value, mutateComment, postAtomData.id, anonymous])
+    mutateComment({ postId: postAtomData.id, content: value, isAnonymous: anonymous }, { onSuccess: clear })
+  }, [value, mutateComment, postAtomData.id, anonymous, clear])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.nativeEvent.isComposing || e.keyCode === 229) return
       if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
-        handleSubmitClick()
+        if (!isKeyDown) {
+          setIsKeyDown(true)
+          handleSubmitClick()
+        }
       }
     },
-    [handleSubmitClick],
+    [handleSubmitClick, isKeyDown],
   )
   const handleAnonymous = useCallback(() => setAnonymous(prev => !prev), [])
-
+  const handleKeyUp = useCallback(() => setIsKeyDown(false), [])
   return (
     <label
       htmlFor="comment"
@@ -68,7 +71,8 @@ const PostComment = memo(() => {
           color: 'darkGray.1',
           _placeholder: { textStyle: 'heading4_M', color: 'lightGray.1' },
         })}
-        onKeyUp={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        onKeyDown={handleKeyDown}
       />
       <div className={css({ display: 'flex', gap: 4, alignItems: 'center' })}>
         <div className={css({ display: 'flex', alignItems: 'center', gap: 1.5 })}>

--- a/src/components/community/post/PostComment.tsx
+++ b/src/components/community/post/PostComment.tsx
@@ -22,7 +22,7 @@ const PostComment = memo(() => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
         handleSubmitClick()
       }

--- a/src/components/community/post/PostComment.tsx
+++ b/src/components/community/post/PostComment.tsx
@@ -10,7 +10,7 @@ import { postAtom } from '@/lib/store/post'
 import { useTextArea } from '@/util/useTextArea'
 
 const PostComment = memo(() => {
-  const { value, onChange } = useTextArea('')
+  const { value, onChange, clear } = useTextArea('')
   const [anonymous, setAnonymous] = useState(false)
   const { mutate: mutateComment } = usePostComment()
   const postAtomData = useAtomValue(postAtom)
@@ -18,10 +18,11 @@ const PostComment = memo(() => {
   const handleSubmitClick = useCallback(() => {
     if (value.trim() === '') return alert('Please enter a comment')
     mutateComment({ postId: postAtomData.id, content: value, isAnonymous: anonymous })
-  }, [anonymous, value, mutateComment, postAtomData.id])
+  }, [value, mutateComment, postAtomData.id, anonymous])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing || e.keyCode === 229) return
       if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault()
         handleSubmitClick()
@@ -67,7 +68,7 @@ const PostComment = memo(() => {
           color: 'darkGray.1',
           _placeholder: { textStyle: 'heading4_M', color: 'lightGray.1' },
         })}
-        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyDown}
       />
       <div className={css({ display: 'flex', gap: 4, alignItems: 'center' })}>
         <div className={css({ display: 'flex', alignItems: 'center', gap: 1.5 })}>

--- a/src/util/useTextArea.ts
+++ b/src/util/useTextArea.ts
@@ -3,5 +3,6 @@ import { useCallback, useState } from 'react'
 export const useTextArea = (initialValue: string) => {
   const [value, setValue] = useState(initialValue)
   const onChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => setValue(e.target.value), [])
-  return { value, onChange }
+  const clear = useCallback(() => setValue(''), [])
+  return { value, onChange, clear }
 }


### PR DESCRIPTION
1. 댓글에서 한글 입력시 onKeyDown 함수 두 번 실행되던 bug fix
2. 대댓글도 같은 로직이었기에 동일하게 처리
3. 댓글, 대댓글 작성 이후 clear() 함수로 텍스트 초기화 핸들링