### PR TITLE
Fix/mypage ux

### DIFF
--- a/src/components/mypage/Contents/ChangePassword.tsx
+++ b/src/components/mypage/Contents/ChangePassword.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { isAxiosError } from 'axios'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -36,6 +37,13 @@ const ChangePassword = () => {
                   onSuccess: () => {
                     reset()
                     alert('Your password has been successfully changed')
+                  },
+                  onError: error => {
+                    if (isAxiosError(error)) {
+                      alert(error.response?.data.message)
+                    } else {
+                      alert('Something is Wrong!')
+                    }
                   },
                 })
               } catch (error) {

--- a/src/components/mypage/Contents/Community/CommentCard.tsx
+++ b/src/components/mypage/Contents/Community/CommentCard.tsx
@@ -1,75 +1,68 @@
-import { css } from '@styled-system/css'
-import { boardTag, reactionButton } from '@styled-system/recipes'
-import { Cookie, MessageCircle } from 'lucide-react'
-import { useCallback } from 'react'
+import { css, cx } from '@styled-system/css'
+import { shadow } from '@styled-system/recipes'
+import { Link } from 'react-router-dom'
 
-import UtilButton from '@/components/community/post/UtilButton'
-import NoticeModal from '@/components/ui/modal/NoticeModal'
-import { POST_MESSAGES } from '@/lib/messages/community'
 import { MyCommentProps } from '@/types/community'
 import { getFormattedTimeString } from '@/util/getFormattedTimeString'
-import { useModal } from '@/util/useModal'
 
 interface CommentCardProps {
   comment: MyCommentProps
 }
 const CommentCard = ({ comment }: CommentCardProps) => {
-  const { isOpen: modalOpen, handleOpen } = useModal(true)
-
-  const handleNavigate = useCallback(() => {
-    window.open(`/community/community/post/${comment.postId}`, '_blank')
-  }, [comment.postId])
-
   return (
-    <div
-      className={css({
-        display: 'flex',
-        flexDir: 'column',
-        alignItems: 'flex-end',
-        gap: 2.5,
-        alignSelf: 'stretch',
-      })}
-    >
+    <Link to={`/community/community/post/${comment.postId}`}>
       <div
         className={css({
           display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
+          flexDir: 'column',
+          alignItems: 'flex-end',
+          gap: '18px',
           alignSelf: 'stretch',
         })}
       >
-        <div className={css({ display: 'flex', alignItems: 'center', gap: 2.5 })}>
-          <div className={boardTag({ variant: 'red' })}>{comment.isAnonymous ? 'Anonymous' : 'Author'}</div>
+        <div
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            alignSelf: 'stretch',
+            gap: 2.5,
+          })}
+        >
+          <div
+            className={cx(
+              css({
+                px: 2.5,
+                py: 1,
+                fontSize: 12,
+                fontWeight: 700,
+                lineHeight: 1.2,
+                color: 'darkGray.2',
+                rounded: 'full',
+                bgColor: 'white',
+              }),
+              shadow(),
+            )}
+          >
+            {comment.isAnonymous ? 'Anonymous' : 'Me'}
+          </div>
           <p className={css({ fontSize: 18, fontWeight: 500, color: 'darkGray.2' })}>
             {getFormattedTimeString(comment.createdAt)}
           </p>
         </div>
-        <UtilButton isComment isMine={true} isEditable={false} forMyPage handleNavigation={handleNavigate} />
+        <p
+          className={css({
+            display: 'flex',
+            alignSelf: 'stretch',
+            whiteSpace: 'pre-wrap',
+            textStyle: 'heading4_M',
+            color: 'darkGray.1',
+            smDown: { fontSize: 14 },
+          })}
+        >
+          {comment.content}
+        </p>
       </div>
-      <p
-        className={css({
-          display: 'flex',
-          alignSelf: 'stretch',
-          whiteSpace: 'pre-wrap',
-          textStyle: 'heading4_M',
-          color: 'darkGray.1',
-          smDown: { fontSize: 14 },
-        })}
-      >
-        {comment.content}
-      </p>
-      <div className={css({ display: 'flex', alignItems: 'center', gap: 2.5 })}>
-        <button className={reactionButton()} onClick={handleNavigate}>
-          <MessageCircle size={22} />
-          <p>{comment.replyCount}</p>
-        </button>
-        <button aria-pressed={false} className={reactionButton()} onClick={handleOpen}>
-          <Cookie size={22} />
-          <p>{comment.likeCount}</p>
-        </button>
-      </div>
-      <NoticeModal content={POST_MESSAGES.NO_LIKE_OWN_COMMENT} isOpen={modalOpen} />
-    </div>
+    </Link>
   )
 }
 

--- a/src/components/mypage/Contents/Community/LikedPost.tsx
+++ b/src/components/mypage/Contents/Community/LikedPost.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { Fragment } from 'react/jsx-runtime'
 
 import { useGetMyReactPost } from '@/api/hooks/community'
 import PostPreview from '@/components/community/PostPreview'
@@ -15,7 +16,7 @@ const LikedPost = () => {
   return (
     <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
       {posts?.map((post, index) => (
-        <>
+        <Fragment key={post.id}>
           {index !== 0 && (
             <div
               className={css({
@@ -26,7 +27,6 @@ const LikedPost = () => {
             />
           )}
           <PostPreview
-            key={post.id}
             id={post.id}
             title={post.title}
             boardName={post.boardName}
@@ -35,7 +35,7 @@ const LikedPost = () => {
             content={post.content}
             thumbnailDir={null}
           />
-        </>
+        </Fragment>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/Community/LikedPost.tsx
+++ b/src/components/mypage/Contents/Community/LikedPost.tsx
@@ -13,18 +13,29 @@ const LikedPost = () => {
   })
 
   return (
-    <div className={css({ display: 'flex', flexDir: 'column', gap: '50px', mb: 25, w: { base: 610, mdDown: 320 } })}>
-      {posts?.map(post => (
-        <PostPreview
-          key={post.id}
-          id={post.id}
-          title={post.title}
-          boardName={post.boardName}
-          user={post.user}
-          createdAt={post.createdAt}
-          content={post.content}
-          thumbnailDir={post.thumbnailDir}
-        />
+    <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
+      {posts?.map((post, index) => (
+        <>
+          {index !== 0 && (
+            <div
+              className={css({
+                w: 'full',
+                h: 0.25,
+                bgColor: 'lightGray.1',
+              })}
+            />
+          )}
+          <PostPreview
+            key={post.id}
+            id={post.id}
+            title={post.title}
+            boardName={post.boardName}
+            user={post.user}
+            createdAt={post.createdAt}
+            content={post.content}
+            thumbnailDir={null}
+          />
+        </>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/Community/MyComments.tsx
+++ b/src/components/mypage/Contents/Community/MyComments.tsx
@@ -14,7 +14,7 @@ const MyComments = () => {
         w: { base: 800, mdDown: 320 },
         flexDir: 'column',
         pb: 200,
-        alignItems: 'flex-start',
+        alignItems: 'stretch',
         gap: 5,
       })}
     >

--- a/src/components/mypage/Contents/Community/MyPost.tsx
+++ b/src/components/mypage/Contents/Community/MyPost.tsx
@@ -13,18 +13,29 @@ const MyPost = () => {
   })
 
   return (
-    <div className={css({ display: 'flex', flexDir: 'column', gap: '50px', mb: 25, w: { base: 610, mdDown: 320 } })}>
-      {posts?.map(post => (
-        <PostPreview
-          key={post.id}
-          id={post.id}
-          title={post.title}
-          boardName={post.boardName}
-          user={post.user}
-          createdAt={post.createdAt}
-          content={post.content}
-          thumbnailDir={post.thumbnailDir}
-        />
+    <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
+      {posts?.map((post, index) => (
+        <>
+          {index !== 0 && (
+            <div
+              className={css({
+                w: 'full',
+                h: 0.25,
+                bgColor: 'lightGray.1',
+              })}
+            />
+          )}
+          <PostPreview
+            key={post.id}
+            id={post.id}
+            title={post.title}
+            boardName={post.boardName}
+            user={post.user}
+            createdAt={post.createdAt}
+            content={post.content}
+            thumbnailDir={null}
+          />
+        </>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/Community/MyPost.tsx
+++ b/src/components/mypage/Contents/Community/MyPost.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { Fragment } from 'react/jsx-runtime'
 
 import { useGetMyPost } from '@/api/hooks/community'
 import PostPreview from '@/components/community/PostPreview'
@@ -15,7 +16,7 @@ const MyPost = () => {
   return (
     <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
       {posts?.map((post, index) => (
-        <>
+        <Fragment key={post.id}>
           {index !== 0 && (
             <div
               className={css({
@@ -26,7 +27,6 @@ const MyPost = () => {
             />
           )}
           <PostPreview
-            key={post.id}
             id={post.id}
             title={post.title}
             boardName={post.boardName}
@@ -35,7 +35,7 @@ const MyPost = () => {
             content={post.content}
             thumbnailDir={null}
           />
-        </>
+        </Fragment>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/Community/MyScrap.tsx
+++ b/src/components/mypage/Contents/Community/MyScrap.tsx
@@ -13,18 +13,29 @@ const MyScrap = () => {
   })
 
   return (
-    <div className={css({ display: 'flex', flexDir: 'column', gap: '50px', mb: 25, w: { base: 610, mdDown: 320 } })}>
-      {posts?.map(post => (
-        <PostPreview
-          key={post.id}
-          id={post.id}
-          title={post.title}
-          boardName={post.boardName}
-          user={post.user}
-          createdAt={post.createdAt}
-          content={post.content}
-          thumbnailDir={post.thumbnailDir}
-        />
+    <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
+      {posts?.map((post, index) => (
+        <>
+          {index !== 0 && (
+            <div
+              className={css({
+                w: 'full',
+                h: 0.25,
+                bgColor: 'lightGray.1',
+              })}
+            />
+          )}
+          <PostPreview
+            key={post.id}
+            id={post.id}
+            title={post.title}
+            boardName={post.boardName}
+            user={post.user}
+            createdAt={post.createdAt}
+            content={post.content}
+            thumbnailDir={null}
+          />
+        </>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/Community/MyScrap.tsx
+++ b/src/components/mypage/Contents/Community/MyScrap.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { Fragment } from 'react/jsx-runtime'
 
 import { useGetMyScrap } from '@/api/hooks/community'
 import PostPreview from '@/components/community/PostPreview'
@@ -15,7 +16,7 @@ const MyScrap = () => {
   return (
     <div className={css({ display: 'flex', flexDir: 'column', gap: '30px', mb: 25, w: { base: 610, mdDown: 320 } })}>
       {posts?.map((post, index) => (
-        <>
+        <Fragment key={post.id}>
           {index !== 0 && (
             <div
               className={css({
@@ -26,7 +27,6 @@ const MyScrap = () => {
             />
           )}
           <PostPreview
-            key={post.id}
             id={post.id}
             title={post.title}
             boardName={post.boardName}
@@ -35,7 +35,7 @@ const MyScrap = () => {
             content={post.content}
             thumbnailDir={null}
           />
-        </>
+        </Fragment>
       ))}
       <div ref={fetchNextRef} />
     </div>

--- a/src/components/mypage/Contents/DeleteAccount.tsx
+++ b/src/components/mypage/Contents/DeleteAccount.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { isAxiosError } from 'axios'
 import { useCallback } from 'react'
 
 import { useDeleteUser } from '@/api/hooks/user'
@@ -26,7 +27,19 @@ const DeleteAccount = () => {
   const { modalRef, isOpen, handleOpen, handleLayoutClose, handleButtonClose } = useModal()
   const { mutate: deleteUser } = useDeleteUser()
 
-  const handleDelete = useCallback(() => deleteUser(), [deleteUser])
+  const handleDelete = useCallback(
+    () =>
+      deleteUser(undefined, {
+        onError: error => {
+          if (isAxiosError(error)) {
+            alert(error.response?.data.message)
+          } else {
+            alert('Something is Wrong!')
+          }
+        },
+      }),
+    [deleteUser],
+  )
 
   return (
     <div className={css({ display: 'flex', gap: { base: 15, mdDown: 5 }, flexDir: 'column', alignItems: 'center' })}>

--- a/src/components/mypage/Contents/ExchangeProfile.tsx
+++ b/src/components/mypage/Contents/ExchangeProfile.tsx
@@ -1,4 +1,5 @@
 import { css } from '@styled-system/css'
+import { isAxiosError } from 'axios'
 import { ShieldAlert } from 'lucide-react'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
@@ -40,6 +41,13 @@ const ExchangeProfile = ({ myProfileData }: ExchangeProfileProps) => {
         { startDay: data.startDay, endDay: data.endDay },
         {
           onSuccess: () => alert('Changed successfully!'),
+          onError: error => {
+            if (isAxiosError(error)) {
+              alert(error.response?.data.message)
+            } else {
+              alert('Something is Wrong!')
+            }
+          },
         },
       )
     } else {

--- a/src/components/mypage/Contents/MyCommunity.tsx
+++ b/src/components/mypage/Contents/MyCommunity.tsx
@@ -1,10 +1,11 @@
 import { css, cva } from '@styled-system/css'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import LikedPost from '@/components/mypage/Contents/Community/LikedPost'
 import MyComments from '@/components/mypage/Contents/Community/MyComments'
 import MyPost from '@/components/mypage/Contents/Community/MyPost'
 import MyScrap from '@/components/mypage/Contents/Community/MyScrap'
+import { useSearch } from '@/util/useSearch'
 
 const ButtonStyle = cva({
   base: {
@@ -44,7 +45,16 @@ const currentViewConfig: Record<ViewType, React.FC> = {
 }
 
 const MyCommunity = () => {
-  const [curView, setCurView] = useState<ViewType>('myPost')
+  const { searchParam, handleSetParam } = useSearch()
+
+  const curView = (searchParam.get('view') ?? 'myPost') as ViewType
+
+  const setCurView = useCallback(
+    (target: ViewType) => {
+      handleSetParam('view', target)
+    },
+    [handleSetParam],
+  )
 
   const ViewComment = useMemo(() => currentViewConfig[curView], [curView])
 

--- a/src/components/mypage/Contents/PointShop/CharacterTicket.tsx
+++ b/src/components/mypage/Contents/PointShop/CharacterTicket.tsx
@@ -13,12 +13,12 @@ const ButtonStyle = cva({
   base: {
     fontSize: { base: 16, mdDown: 11 },
     fontWeight: 600,
-    bgColor: 'red.2',
     py: '3px',
     px: 3,
     rounded: 'full',
     color: 'white',
-    cursor: 'pointer',
+    border: '1px solid',
+    transition: 'all 0.2s',
   },
   variants: {
     visible: {
@@ -27,6 +27,17 @@ const ButtonStyle = cva({
       },
       false: {
         visibility: 'hidden',
+      },
+    },
+    available: {
+      true: {
+        bgColor: 'red.2',
+        borderColor: 'red.2',
+        cursor: 'pointer',
+      },
+      false: {
+        bgColor: 'lightGray.1',
+        borderColor: 'darkGray.2',
       },
     },
   },
@@ -190,7 +201,7 @@ const CharacterTicket = ({
           {canBuy && (
             <button
               className={cx(
-                ButtonStyle(),
+                ButtonStyle({ available: true }),
                 css({
                   position: 'absolute',
                   bottom: { base: '18px', mdDown: 2 },
@@ -206,7 +217,10 @@ const CharacterTicket = ({
           )}
         </div>
         <button
-          className={ButtonStyle({ visible: selectedLevel !== level && level <= myLevel })}
+          className={ButtonStyle({
+            visible: level !== 0 && level <= myLevel,
+            available: selectedLevel !== level,
+          })}
           onClick={() => handleApply(level)}
         >
           Apply

--- a/src/components/mypage/Contents/PointShop/Showcase.tsx
+++ b/src/components/mypage/Contents/PointShop/Showcase.tsx
@@ -51,6 +51,7 @@ const Showcase = ({ myLevel, selectedLevel, myCharacterType }: ShowcaseProps) =>
           onSuccess: () => {
             // TODO: 캐릭터 로직
             alert('Your purchase has been successful')
+            window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
           },
           onError: error => {
             if (isAxiosError(error)) {

--- a/src/components/mypage/Contents/PointShop/Showcase.tsx
+++ b/src/components/mypage/Contents/PointShop/Showcase.tsx
@@ -66,9 +66,13 @@ const Showcase = ({ myLevel, selectedLevel, myCharacterType }: ShowcaseProps) =>
   )
   const handleApplyCharacter = useCallback(
     (target: number) => {
-      selectLevel(target)
+      if (selectedLevel !== target) {
+        selectLevel(target)
+        // TODO: 스크롤 애니메이션 컨펌 받기
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+      }
     },
-    [selectLevel],
+    [selectLevel, selectedLevel],
   )
 
   return (

--- a/src/components/mypage/Contents/PointShop/Showcase.tsx
+++ b/src/components/mypage/Contents/PointShop/Showcase.tsx
@@ -49,7 +49,6 @@ const Showcase = ({ myLevel, selectedLevel, myCharacterType }: ShowcaseProps) =>
         { itemCategory: type, requiredPoints: cost },
         {
           onSuccess: () => {
-            // TODO: 캐릭터 로직
             alert('Your purchase has been successful')
             window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
           },

--- a/src/lib/recipes/tag.ts
+++ b/src/lib/recipes/tag.ts
@@ -12,7 +12,7 @@ export const tagRecipe = defineRecipe({
     gap: 1.5,
     alignSelf: 'stretch',
     rounded: 'full',
-    bgCololr: 'white',
+    bgColor: 'white',
     boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.25)',
     color: 'darkGray.2',
   },


### PR DESCRIPTION
지금까지 나왔던 My Page UX 관련 개선 사항 적용했습니다

- 캐릭터 변경 성공적으로 완료 후 Scroll Up
- Password / Profile 정보 수정 시 에러가 났을 때의 대응
- Apply Btn 비활성화 상태 구현을 통해 어디까지 해금되어있는지 가시화 & 버튼 이동되는 것처럼 보이는 경험 수정 <img width="425" alt="Screenshot 2024-09-15 at 7 17 46 PM" src="https://github.com/user-attachments/assets/6cb9b28c-be2b-43f5-b7a7-85a5e869c587">
- Community 모아보기의 댓글 뷰 & 게시글 뷰 수정 <img width="681" alt="Screenshot 2024-09-15 at 7 18 29 PM" src="https://github.com/user-attachments/assets/9ec40b1c-f002-4028-9fd3-6614f2cf58d4">
