### PR TITLE
[#76] Meta Tag 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/Logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>KU-key</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,11 +1,11 @@
 import { css } from '@styled-system/css'
 import { useEffect } from 'react'
-import { Helmet } from 'react-helmet-async'
 import { Outlet } from 'react-router-dom'
 
 import { useCheckVerified } from '@/api/hooks/auth'
 import Footer from '@/components/Footer'
 import Header from '@/components/Header'
+import MetaTag from '@/components/MetaTag'
 import { useAuth } from '@/util/auth/useAuth'
 
 const MainLayout = () => {
@@ -16,9 +16,7 @@ const MainLayout = () => {
   }, [verified, setVerified])
   return (
     <div className={css({ display: 'flex', flexDir: 'column', h: '100vh' })}>
-      <Helmet>
-        <title>KU-key</title>
-      </Helmet>
+      <MetaTag title="KU-key" />
       <Header />
       <div className={css({ flex: 1 })}>
         <Outlet />

--- a/src/components/MetaTag.tsx
+++ b/src/components/MetaTag.tsx
@@ -1,0 +1,41 @@
+import { Helmet } from 'react-helmet-async'
+
+interface MetaTagProps {
+  title: string
+  description?: string
+  keywords?: string
+  imgSrc?: string
+}
+const MetaTag = ({
+  title,
+  description = 'KU-key is a service designed to help international students on exchange to Korea University have a more convenient school life. Meet friends in KU-key and manage your school life conveniently!',
+  keywords,
+  imgSrc = 'https://kukeyrun.s3.amazonaws.com/fe/metaImg.jpg',
+}: MetaTagProps) => {
+  const adjKeywords = `${keywords === undefined ? '' : `${keywords}, `}exchange student, Korea University, KU, KU-key, kukey, Korea Univ, 고려대학교, 쿠키, exchange, timetable, everytime`
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+
+      <meta name="description" content={description} />
+      <meta name="keywords" content={adjKeywords} />
+
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={title} />
+      <meta property="og:site_name" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imgSrc} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imgSrc} />
+      <meta property="twitter:image:width" content="1200" />
+      <meta property="twitter:image:height" content="630" />
+    </Helmet>
+  )
+}
+
+export default MetaTag

--- a/src/pages/ClubPage.tsx
+++ b/src/pages/ClubPage.tsx
@@ -68,7 +68,7 @@ const ClubPage = () => {
     <>
       <MetaTag
         title="Club"
-        description="We introduce you to various clubs at Korea University! Find out what clubs there are and what each club's characteristics are."
+        description="Meet the various clubs at Korea University! Find out what clubs there are and what each club's characteristics are."
         keywords="club, clubs"
       />
       <div

--- a/src/pages/ClubPage.tsx
+++ b/src/pages/ClubPage.tsx
@@ -6,6 +6,7 @@ import CategorySelector from '@/components/club/CategorySelector'
 import ClubCard from '@/components/club/ClubCard'
 import { CategoryType } from '@/components/club/constants'
 import SearchArea from '@/components/club/SearchArea'
+import MetaTag from '@/components/MetaTag'
 import { Checkbox } from '@/components/ui/checkbox'
 import { useAuth } from '@/util/auth/useAuth'
 import useScrollUp from '@/util/useScrollUp'
@@ -65,6 +66,11 @@ const ClubPage = () => {
 
   return (
     <>
+      <MetaTag
+        title="Club"
+        description="We introduce you to various clubs at Korea University! Find out what clubs there are and what each club's characteristics are."
+        keywords="club, clubs"
+      />
       <div
         className={css({
           h: { base: '400px', mdDown: '200px' },

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { useGetAcademicCalendar } from '@/api/hooks/calendar'
 import koreaUniv from '@/assets/koreaUniv.png'
 import AcademicCalendar from '@/components/calendar/AcademicCalendar'
+import MetaTag from '@/components/MetaTag'
 import Dropdown from '@/components/timetable/Dropdown'
 import { useAcademicSemester } from '@/util/academicCalendar'
 import { makeSemesterDropdownList } from '@/util/timetableUtil'
@@ -27,6 +28,11 @@ const SchedulePage = () => {
 
   return (
     <>
+      <MetaTag
+        title="Academic Schedule"
+        description="Check out Korea University's academic calendar at a glance."
+        keywords="schedule, academic, academic schedule, calendar, academic calendar"
+      />
       <div
         className={css({
           h: { base: '400px', mdDown: '200px' },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5dfe3897-7d55-4663-a4f3-0286c8dd4469)
SNS에서 쿠키 공유할 때 미리보기가 Vite + React + TS으로 나와서(!!!)
메타 태그를 구현해보았습니다

`react-helmet-async`의 `Helmet`을 이용했고, 페이지에 심기 쉽도록 따로 컴포넌트로 구현했습니다
잘 표시되는지는... vercel 프리뷰에는 안 떠서 dev 머지되고 확인해봐야할듯합니다

일단 당장 공유할만한 페이지가
로그인하지 않아도 볼 수 있는
- 홈 화면
- 동아리 모아보기
- 학사일정 모아보기

정도인 거 같아 이 세개에 테스트 삼아 적용해보았고,
만약 다른 페이지에 메타태그가 필요하면 `<MetaTag />`로 설정하면 될 거 같아요