### PR TITLE
[KK-57] fix: Footer 라우팅 버그, 메뉴 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { useRoutes } from 'react-router-dom'
 import routes from '@/lib/router/router'
 import AmplitudeProvider from '@/util/AmplitudeProvider'
 import AuthProvider from '@/util/auth/AuthProvider'
+import ScrollToTop from '@/util/ScrollToTop'
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -21,6 +23,7 @@ function App() {
       {/* <ReactQueryDevtools initialIsOpen={false} /> */}
       <AuthProvider />
       <AmplitudeProvider />
+      <ScrollToTop />
       {router}
     </QueryClientProvider>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -126,7 +126,7 @@ const Footer = () => {
         })}
       >
         {footerRouteConfig.map(nav => (
-          <Link to={`/${nav.route}`} className={tabs} onClick={e => handleNavClick(e, nav.route)}>
+          <Link key={nav.route} to={`/${nav.route}`} className={tabs} onClick={e => handleNavClick(e, nav.route)}>
             {nav.navName}
           </Link>
         ))}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,16 @@
 import { css } from '@styled-system/css'
+import { useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 // TODO: ADD Instagram & Notion Link
 // import instagramIcon from '@/assets/instagram.svg'
 import KUkeyLogo from '@/assets/KU-keyLogo.svg'
 import mailIcon from '@/assets/mail.svg'
+import NoticeModal from '@/components/ui/modal/NoticeModal'
+import { HEADER_MESSAGE } from '@/lib/messages/header'
+import { footerRouteConfig } from '@/lib/router/footer-route'
+import { useAuth } from '@/util/auth/useAuth'
+import { useModal } from '@/util/useModal'
 // import notionIcon from '@/assets/notion.svg'
 
 const supportApps = [
@@ -26,8 +32,31 @@ const tabs = css({
 })
 
 const Footer = () => {
+  const { isAuthenticated, authState } = useAuth()
+  const { isOpen: isModalOpen, handleOpen: handleModalOpen } = useModal(true)
+  const [modalContent, setModalContent] = useState(HEADER_MESSAGE.NOT_VERIFIED_USER)
+
+  const handleNavClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, route: string) => {
+      if (route === 'matching') {
+        e.preventDefault()
+        setModalContent(HEADER_MESSAGE.NOT_READY)
+        handleModalOpen()
+        return
+      }
+      if (!isAuthenticated) return // 미로그인 유저
+      if (!authState) {
+        // 인증 안 된 유저
+        e.preventDefault()
+        setModalContent(HEADER_MESSAGE.NOT_VERIFIED_USER)
+        handleModalOpen()
+      }
+    },
+    [authState, handleModalOpen, isAuthenticated],
+  )
+
   return (
-    <div
+    <footer
       className={css({
         w: 'full',
         borderTop: '1.211px solid {colors.lightGray.2}',
@@ -96,20 +125,14 @@ const Footer = () => {
           h: 25,
         })}
       >
-        <Link to="/" className={tabs}>
-          MY PAGE
-        </Link>
-        <Link to="/timetable" className={tabs}>
-          TIMETABLE
-        </Link>
-        <Link to="/community" className={tabs}>
-          COMMUNITY
-        </Link>
-        <Link to="/matching" className={tabs}>
-          1:1 MATCHING
-        </Link>
+        {footerRouteConfig.map(nav => (
+          <Link to={`/${nav.route}`} className={tabs} onClick={e => handleNavClick(e, nav.route)}>
+            {nav.navName}
+          </Link>
+        ))}
       </div>
-    </div>
+      <NoticeModal isOpen={isModalOpen} content={modalContent} />
+    </footer>
   )
 }
 

--- a/src/lib/router/footer-route.ts
+++ b/src/lib/router/footer-route.ts
@@ -1,0 +1,7 @@
+export const footerRouteConfig = [
+  { route: 'mypage', navName: 'MY PAGE' },
+  { route: 'timetable', navName: 'TIMETABLE' },
+  { route: 'timetable/friend', navName: 'FRIENDS' },
+  { route: 'community', navName: 'COMMUNITY' },
+  { route: 'matching', navName: '1:1 MATCHING' },
+]

--- a/src/pages/ClubPage.tsx
+++ b/src/pages/ClubPage.tsx
@@ -9,12 +9,9 @@ import SearchArea from '@/components/club/SearchArea'
 import MetaTag from '@/components/MetaTag'
 import { Checkbox } from '@/components/ui/checkbox'
 import { useAuth } from '@/util/auth/useAuth'
-import useScrollUp from '@/util/useScrollUp'
 import { useSearch } from '@/util/useSearch'
 
 const ClubPage = () => {
-  useScrollUp()
-
   const isLogin = useAuth().authState ?? false
 
   const { searchParam, handleSetParam, deleteParam } = useSearch()

--- a/src/pages/CommunityPage/PostViewPage.tsx
+++ b/src/pages/CommunityPage/PostViewPage.tsx
@@ -2,10 +2,8 @@ import { css, cx } from '@styled-system/css'
 import { globalLayout } from '@styled-system/recipes'
 
 import PostView from '@/components/community/post/PostView'
-import useScrollUp from '@/util/useScrollUp'
 
 const PostViewPage = () => {
-  useScrollUp()
   return (
     <main className={css({ display: 'flex', flexDir: 'column' })}>
       <div

--- a/src/pages/CourseReviewPage/ReviewDetailPage.tsx
+++ b/src/pages/CourseReviewPage/ReviewDetailPage.tsx
@@ -6,10 +6,8 @@ import InfoDetail from '@/components/courseReview/InfoDetail'
 import Review from '@/components/courseReview/Review'
 import { courseSummary } from '@/lib/store/review'
 import { ReviewType } from '@/types/review'
-import useScrollUp from '@/util/useScrollUp'
 
 const ReviewDetailPage = () => {
-  useScrollUp()
   const data = useLocation().state as ReviewType
   const infoData = useAtomValue(courseSummary)
   return (

--- a/src/pages/CourseReviewPage/WriteReviewPage.tsx
+++ b/src/pages/CourseReviewPage/WriteReviewPage.tsx
@@ -21,7 +21,6 @@ import {
   teamProjectArray,
 } from '@/util/reviewUtil'
 import { getCurSemester, makeSemesterDropdownList, timetablePreprocess } from '@/util/timetableUtil'
-import useScrollUp from '@/util/useScrollUp'
 
 interface WriteReviewForm {
   rate: number
@@ -38,7 +37,6 @@ interface WriteReviewForm {
 }
 
 const WriteReviewPage = () => {
-  useScrollUp()
   const { courseCode = '', prof = '' } = useParams()
 
   const navigate = useNavigate()

--- a/src/util/ScrollToTop.tsx
+++ b/src/util/ScrollToTop.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const ScrollToTop = () => {
+  const location = useLocation()
+  const curPath = location.pathname
+  const curPathRoot = curPath.split('/')[1]
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [curPathRoot])
+
+  return <></>
+}
+
+export default ScrollToTop

--- a/src/util/ScrollToTop.tsx
+++ b/src/util/ScrollToTop.tsx
@@ -4,16 +4,10 @@ import { useLocation } from 'react-router-dom'
 const ScrollToTop = () => {
   const location = useLocation()
   const curPath = location.pathname
-  const curPathRoot = curPath.split('/')[1]
-
-  // timetable은 예외로 항상 스크롤 초기화
-  if (curPathRoot === 'timetable') {
-    window.scrollTo(0, 0)
-  }
 
   useEffect(() => {
     window.scrollTo(0, 0)
-  }, [curPathRoot])
+  }, [curPath])
 
   return <></>
 }

--- a/src/util/ScrollToTop.tsx
+++ b/src/util/ScrollToTop.tsx
@@ -5,6 +5,14 @@ const ScrollToTop = () => {
   const location = useLocation()
   const curPath = location.pathname
   const curPathRoot = curPath.split('/')[1]
+  const curPathLeaf = curPath.split('/')[2]
+
+  useEffect(() => {
+    // timetable은 예외로 항상 스크롤 초기화
+    if (curPathRoot === 'timetable') {
+      window.scrollTo(0, 0)
+    }
+  }, [curPathLeaf, curPathRoot])
 
   useEffect(() => {
     window.scrollTo(0, 0)

--- a/src/util/ScrollToTop.tsx
+++ b/src/util/ScrollToTop.tsx
@@ -5,14 +5,11 @@ const ScrollToTop = () => {
   const location = useLocation()
   const curPath = location.pathname
   const curPathRoot = curPath.split('/')[1]
-  const curPathLeaf = curPath.split('/')[2]
 
-  useEffect(() => {
-    // timetable은 예외로 항상 스크롤 초기화
-    if (curPathRoot === 'timetable') {
-      window.scrollTo(0, 0)
-    }
-  }, [curPathLeaf, curPathRoot])
+  // timetable은 예외로 항상 스크롤 초기화
+  if (curPathRoot === 'timetable') {
+    window.scrollTo(0, 0)
+  }
 
   useEffect(() => {
     window.scrollTo(0, 0)

--- a/src/util/useScrollUp.ts
+++ b/src/util/useScrollUp.ts
@@ -1,9 +1,0 @@
-import { useEffect } from 'react'
-
-const useScrollUp = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0)
-  }, [])
-}
-
-export default useScrollUp


### PR DESCRIPTION
https://www.notion.so/Footer-814a93ba79454cd08e923c78a50fa4bb
에 대한 대응입니다.

header의 라우팅 방식을 살짝 바꿔 적용했고,
기존 footer가 라우팅이 돼도 스크롤이 그대로 유지되어 UX가 부자연스럽던 상황을 개선했습니다.
이제 base path가 달라지면 기본적으로 스크롤이 가장 위 상단으로 옮겨지게됩니다
(`ScrollToTop.tsx`에서 예외처리 가능)