### PR TITLE
[KK-1] fix: 회원가입 필드명 변경

### DIFF
--- a/src/components/register/UserInfoForm.tsx
+++ b/src/components/register/UserInfoForm.tsx
@@ -92,7 +92,7 @@ const UserInfoForm = ({ form, handleFileChange, handleValidation, valid, fileNam
               rowGap: 2.5,
             })}
           >
-            <FormLabel>Country</FormLabel>
+            <FormLabel>Nation</FormLabel>
             <FormControl>
               <div
                 className={css({
@@ -135,7 +135,7 @@ const UserInfoForm = ({ form, handleFileChange, handleValidation, valid, fileNam
               rowGap: 2.5,
             })}
           >
-            <FormLabel>Home UNIV</FormLabel>
+            <FormLabel>Origin Univ</FormLabel>
             <FormControl>
               <div
                 className={css({
@@ -209,7 +209,7 @@ const UserInfoForm = ({ form, handleFileChange, handleValidation, valid, fileNam
               rowGap: 2.5,
             })}
           >
-            <FormLabel>Student ID</FormLabel>
+            <FormLabel>KU Student ID</FormLabel>
             <FormControl>
               <div
                 className={css({


### PR DESCRIPTION
### 📌 내용

- student ID → Korea University Student ID로 변경해야 할 것 같아요. `강경아` @acvxx 
위에서 Home UNIV & Major를 물어봐서 기존 학교의 학번을 넣을 것 같아요.
- 회원가입과 용어 sync 필요 (Origin univ <> Home univ, Nation <> Country) `강경아` @acvxx 
 → 회원가입 필드명 변경하는 김에 회원가입 페이지에서 싱크 맞추시죠

### ☑️ 체크 사항

- [x] - student ID → KU Student ID
- [x] - Home Univ → Origin Univ
- [x] - Country → Nation