### PR TITLE
[KK-52] feat: 미인증 유저 알람 기능 막기

### DIFF
--- a/src/components/header/NotifyWindow.tsx
+++ b/src/components/header/NotifyWindow.tsx
@@ -2,13 +2,29 @@ import * as Popover from '@radix-ui/react-popover'
 import { css, cx } from '@styled-system/css'
 import { shadow } from '@styled-system/recipes'
 import { Bell } from 'lucide-react'
+import { useCallback } from 'react'
 
 import AttendanceBtn from '@/components/header/notification/AttendanceBtn'
+import NoticeModal from '@/components/ui/modal/NoticeModal'
+import { HEADER_MESSAGE } from '@/lib/messages/header'
+import { useAuth } from '@/util/auth/useAuth'
+import { useModal } from '@/util/useModal'
 
 const NotifyWindow = () => {
+  const { isOpen, handleOpen } = useModal(true)
+  const { authState } = useAuth()
+  const handlePopoverClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      if (!authState) {
+        e.preventDefault()
+        handleOpen()
+      }
+    },
+    [authState, handleOpen],
+  )
   return (
     <Popover.Root>
-      <Popover.Trigger asChild>
+      <Popover.Trigger asChild onClick={handlePopoverClick}>
         <button className={css({ display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer' })}>
           <Bell size={20} />
         </button>
@@ -52,6 +68,7 @@ const NotifyWindow = () => {
           </div>
         </Popover.Content>
       </Popover.Portal>
+      <NoticeModal isOpen={isOpen} content={HEADER_MESSAGE.NOT_VERIFIED_USER} />
     </Popover.Root>
   )
 }


### PR DESCRIPTION
### 📌 내용

- 로그인 but not confirm의 경우, header에서 어차피 아무 기능도 못 쓰니까 알림도 보지 못하게 막아야 할 것 같아요 `강경아`

### ☑️ 체크 사항

- [x] - 미인증 유저의 경우 알람을 눌렀을 때 막히는지
- [x] - 인증 유저는 원래대로 작동하는지

