### PR TITLE
[KK-59] fix: 강의평 좋아요 모아보기 임시 배제

### DIFF
--- a/src/pages/CourseReviewPage/ReviewPage.tsx
+++ b/src/pages/CourseReviewPage/ReviewPage.tsx
@@ -96,12 +96,13 @@ const ReviewPage = () => {
               >
                 Latest
               </button>
-              <button
+              {/* TODO: 강의평 좋아요 기능 추가 & 좋아요 순으로 모아보기 */}
+              {/* <button
                 className={CriteriaBtnStyle({ selected: criteria === 'recommendCount' })}
                 onClick={() => setCriteria('recommendCount')}
               >
                 Like
-              </button>
+              </button> */}
               <button
                 className={CriteriaBtnStyle({ selected: criteria === 'rate' })}
                 onClick={() => setCriteria('rate')}


### PR DESCRIPTION
### 📌 내용

- Filter에서 Like 기준으로에서 ASC, DESC 바꾸어도 아무 변화 없어요.
- 일단 강의평 추천 기능이 들어오기 전까지 **Like 정렬을 UI에서 제외**해요. 추후 할일 목록에 추가해둘게요.
    - [강의평 추천 기능을 추가해요](https://www.notion.so/112bb3ab3b248096ad53cde2f891f780?pvs=21)

<img width="853" alt="Screenshot 2024-10-02 at 1 38 38 AM" src="https://github.com/user-attachments/assets/38db0394-81af-4140-8e38-1e69b68bdb1e">

### ☑️ 체크 사항

- [x] 강의평 모아보기 페이지에서 (/course-review/detail/{학수번호}/{교수님성함}) Like가 제대로 제외되었는지

