### PR TITLE
[KK-19] fix: 이미지 미로딩 시 처리 개선

### DIFF
--- a/src/components/home/Carousel/index.tsx
+++ b/src/components/home/Carousel/index.tsx
@@ -25,7 +25,7 @@ const SkeletonImg = ({ imageUrl, index }: { imageUrl: string; index: number }) =
         className={BannerStyle({ display: !isImgLoading })}
         onError={e => {
           e.currentTarget.onerror = null
-          e.currentTarget.remove()
+          setIsImgLoading(false)
         }}
         onLoad={() => {
           setIsImgLoading(false)

--- a/src/components/home/Carousel/index.tsx
+++ b/src/components/home/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import { css, cva, cx } from '@styled-system/css'
+import { css, cva } from '@styled-system/css'
 import Autoplay from 'embla-carousel-autoplay'
 import useEmblaCarousel, { UseEmblaCarouselType } from 'embla-carousel-react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
@@ -9,21 +9,24 @@ import PlayIcon from '@/assets/play.svg'
 import { usePrevNextButtons } from '@/util/carousel-button'
 
 const BannerStyle = cva({
-  base: { w: '608px', ml: 5, flex: '0 0 auto', display: 'block' },
+  base: { w: '608px', h: '300px', ml: 5, flex: '0 0 auto', display: 'block' },
   variants: { display: { false: { display: 'none' } } },
 })
-const SkeletonBannerStyle = cx(BannerStyle(), css({ h: '300px' }))
 
 const SkeletonImg = ({ imageUrl, index }: { imageUrl: string; index: number }) => {
   const [isImgLoading, setIsImgLoading] = useState(true)
 
   return (
     <>
-      {isImgLoading && <div className={SkeletonBannerStyle} />}
+      {isImgLoading && <div className={BannerStyle()} />}
       <img
         src={imageUrl}
         alt={`banner-${index}`}
         className={BannerStyle({ display: !isImgLoading })}
+        onError={e => {
+          e.currentTarget.onerror = null
+          e.currentTarget.remove()
+        }}
         onLoad={() => {
           setIsImgLoading(false)
         }}
@@ -71,9 +74,7 @@ const HomeCarousel = () => {
             ? banners.map(({ imageUrl }, index) => (
                 <SkeletonImg key={`banner-img-${index}`} imageUrl={imageUrl} index={index} />
               ))
-            : Array.from({ length: 5 }, (_, index) => (
-                <div key={`banner-img-${index}`} className={SkeletonBannerStyle} />
-              ))}
+            : Array.from({ length: 5 }, (_, index) => <div key={`banner-img-${index}`} className={BannerStyle()} />)}
         </div>
       </div>
       <div


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- safari에서 배너 안 나와요 `강경아`
    - safari 껐다 켰더니 배너 잘 나왔음
    - 초기에 잘못 불러온 상태로 재시도를 안 하는 것 같음
![image](https://github.com/user-attachments/assets/f35f8a42-cb60-4390-8f7f-e86888ea4404)

### 논의해보고 싶은 지점
우선 현재 img load fail 시 레이아웃이 부자연스럽게 보이는 버그가 있어서, 그거 위주로 해결했습니다.

다만 경아님 리뷰를 보니 이미지가 제대로 불러와지지 않은 경우, 재시도에 대한 리뷰가 있는데
요런 로직 처리가 가능한지 궁금하네요

S3링크는 올바른데, 이미지 불러오는 데 실패했을 때 retry 처리 하는 것에 대해 혹시 아는 바가 있으신가요
좋은 방안이 있다면 적용해보겠습니다!

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 이미지가 제대로 불러와지지 않을 때 레이아웃이 자연스럽게 보이는지
(개발자 도구의 network 탭에서 banner url에 대한 request를 block하여 테스팅해볼 수 있습니다)

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
