### PR TITLE
fix(mod): Amplitude Key 없으면 안 달리도록, Console Warning 해결

### DIFF
--- a/src/util/AmplitudeProvider.tsx
+++ b/src/util/AmplitudeProvider.tsx
@@ -1,7 +1,10 @@
 import { init } from '@amplitude/analytics-browser'
 
 const AmplitudeProvider = () => {
-  init(import.meta.env.VITE_API_AMPLITUDE_API_KEY)
+  if (import.meta.env.VITE_API_AMPLITUDE_API_KEY) {
+    // TODO: defaultTracking is deprecated
+    init(import.meta.env.VITE_API_AMPLITUDE_API_KEY, { defaultTracking: true })
+  }
 
   return <></>
 }


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- .env에 보관된 앰플리튜드 키가 없을 시, init 로직이 작동하지 않습니다
- console에 warning을 표시하는 defaultTracking 옵션을 설정합니다

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
