### PR TITLE
[KK-86] fix(typo): 잘못 표기된 포인트 instruction

### DIFF
--- a/src/components/ui/modal/SugarModal.tsx
+++ b/src/components/ui/modal/SugarModal.tsx
@@ -94,7 +94,7 @@ const SugarModal = (props: SugarModalProps) => {
                 <span>Attendance</span>
                 <span>
                   <img src={Sugar} alt="sugar" />
-                  30
+                  10
                 </span>
               </div>
               <div className={HowToContent}>
@@ -121,12 +121,12 @@ const SugarModal = (props: SugarModalProps) => {
                 <span className={CostInterval}>
                   <div>
                     <img src={Sugar} alt="sugar" />
-                    100
+                    30
                   </div>
                   <span>-</span>
                   <div>
                     <img src={Sugar} alt="sugar" />
-                    30
+                    100
                   </div>
                 </span>
               </div>
@@ -135,12 +135,12 @@ const SugarModal = (props: SugarModalProps) => {
                 <span className={CostInterval}>
                   <div>
                     <img src={Sugar} alt="sugar" />
-                    400
+                    30
                   </div>
                   <span>-</span>
                   <div>
                     <img src={Sugar} alt="sugar" />
-                    30
+                    400
                   </div>
                 </span>
               </div>


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

> 출석체크 시 30p 지급으로 나와있는데 10p를 지급하네요.

- 포인트 가이드가 잘못되어, 출석체크 시 받을 수 있는 Sugar를 10p로 조정하였습니다
- 기존 `100 - 30`과 `400 - 30`으로 표기된 instruction 순서를, 각각 `30 - 100`과 `30 - 400`으로 수정하였습니다

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [x] 출석체크 포인트가 올바르게 바뀌었는지
- [x] 구간 포인트 표기의 순서가 올바르게 바뀌었는지