### PR TITLE
[KK-79] feat: 질문게시판 본인 댓글 util button 막기

### DIFF
--- a/src/components/community/post/CommentHeader.tsx
+++ b/src/components/community/post/CommentHeader.tsx
@@ -88,7 +88,7 @@ const CommentHeader = ({
           isDeletable={isMyComment && boardName !== 'question'}
           handleReport={() => handleTargetAndOpen('report')}
           handleDelete={() => handleTargetAndOpen('delete')}
-          disabled={isDeleted}
+          disabled={isDeleted || (isMyComment && boardName === 'question')}
         />
       )}
       <AlertModal

--- a/src/components/community/post/UtilButton.tsx
+++ b/src/components/community/post/UtilButton.tsx
@@ -42,6 +42,7 @@ const UtilButton = ({
             rounded: 'full',
             w: '30px',
             h: '30px',
+            visibility: disabled ? 'hidden' : 'visible',
             _hover: { bgColor: 'lightGray.1', transition: 'background-color 0.25s ease-in-out' },
             _open: { bgColor: 'lightGray.1', transition: 'background-color 0.25s ease-in-out' },
           })}


### PR DESCRIPTION
## 📌 내용

- question board에서 자신이 쓴 댓글에 … 눌렀을 때 삭제 버튼 안 뜨고 이상한 동그라미가 떠요 `강경아` @acvxx 
    - 삭제 기능이 없다면
        1. …도 없거나
        2. 눌렀을 때 아무것도 안 떠야 할 것 같아요

질문 게시판은 본인 댓글은 애초에 작동할 수 있는 기능이 없어서 아예 눌렀을 때 반응이 없도록 막았어요.


## ☑️ 체크 사항

- [x] 질문 게시판의 경우, 본인의 댓글일 때 유틸 버튼이  disabled 되어있는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
