### PR TITLE
[KK-72] fix: 게시글 제목, 본문, 댓글, 대댓글 길이 제한 도달시 줄 바꿈

### DIFF
--- a/src/components/community/post/Comment.tsx
+++ b/src/components/community/post/Comment.tsx
@@ -64,11 +64,11 @@ const Comment = memo(({ isOpen, currentIndex, handleClick }: CommentProps) => {
           textStyle: 'heading4_M',
           color: 'darkGray.1',
           smDown: { fontSize: 14 },
+          wordBreak: 'break-word',
         })}
       >
         {comment.content || 'This comment has been deleted.'}
       </p>
-
       <div
         className={css({
           display: 'flex',

--- a/src/components/community/post/CommentReply.tsx
+++ b/src/components/community/post/CommentReply.tsx
@@ -62,6 +62,7 @@ const CommentReply = ({ reply, parentId }: CommentReplyProps) => {
             display: 'flex',
             alignSelf: 'stretch',
             whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
             textStyle: 'heading4_M',
             color: 'darkGray.1',
             smDown: { fontSize: 14 },

--- a/src/components/community/post/Post.tsx
+++ b/src/components/community/post/Post.tsx
@@ -119,18 +119,10 @@ const Post = memo(() => {
           alignSelf: 'stretch',
         })}
       >
-        <h1
-          className={css({
-            fontSize: 26,
-            fontWeight: 600,
-            color: 'black.2',
-            alignSelf: 'stretch',
-            whiteSpace: 'pre-wrap',
-          })}
-        >
+        <h1 className={css({ textStyle: 'title3', color: 'black.2', alignSelf: 'stretch', whiteSpace: 'pre-wrap' })}>
           {postAtomData.title}
         </h1>
-        <p className={css({ fontSize: 18, fontWeight: 500, color: 'darkGray.1', whiteSpace: 'pre-wrap' })}>
+        <p className={css({ textStyle: 'heading4_M', color: 'darkGray.1', maxW: '48.5rem', whiteSpace: 'pre-wrap' })}>
           {postAtomData.content}
         </p>
       </section>

--- a/src/components/community/post/Post.tsx
+++ b/src/components/community/post/Post.tsx
@@ -119,10 +119,25 @@ const Post = memo(() => {
           alignSelf: 'stretch',
         })}
       >
-        <h1 className={css({ textStyle: 'title3', color: 'black.2', alignSelf: 'stretch', whiteSpace: 'pre-wrap' })}>
+        <h1
+          className={css({
+            textStyle: 'title3',
+            color: 'black.2',
+            alignSelf: 'stretch',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          })}
+        >
           {postAtomData.title}
         </h1>
-        <p className={css({ textStyle: 'heading4_M', color: 'darkGray.1', maxW: '48.5rem', whiteSpace: 'pre-wrap' })}>
+        <p
+          className={css({
+            textStyle: 'heading4_M',
+            color: 'darkGray.1',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          })}
+        >
           {postAtomData.content}
         </p>
       </section>

--- a/src/components/community/post/PostView.tsx
+++ b/src/components/community/post/PostView.tsx
@@ -48,7 +48,16 @@ const PostView = () => {
           <ArrowLeft />
           PREV
         </Button>
-        <div className={css({ display: 'flex', w: 817, flexDir: 'column', alignItems: 'flex-start', gap: '50px' })}>
+        <div
+          className={css({
+            display: 'flex',
+            w: 817,
+            flexDir: 'column',
+            alignItems: 'flex-start',
+            gap: '50px',
+            maxW: '51rem',
+          })}
+        >
           <Post />
           <PostComment />
           <CommentView />

--- a/src/lib/recipes/post-card.ts
+++ b/src/lib/recipes/post-card.ts
@@ -14,5 +14,6 @@ export const postCardRecipe = defineRecipe({
     alignSelf: 'stretch',
     boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.25)',
     rounded: 10,
+    maxW: '51rem',
   },
 })

--- a/src/lib/recipes/textStyles.ts
+++ b/src/lib/recipes/textStyles.ts
@@ -25,7 +25,7 @@ export const textStyles = defineTextStyles({
   heading4_M: {
     description: 'Heading 4 Medium',
     value: {
-      fontSize: 18,
+      fontSize: '1.125rem',
       fontWeight: 500,
     },
   },
@@ -82,7 +82,7 @@ export const textStyles = defineTextStyles({
   title3: {
     description: 'Title 3',
     value: {
-      fontSize: 26,
+      fontSize: '1.625rem',
       fontWeight: 600,
     },
   },


### PR DESCRIPTION
## 📌 내용

- 내용이 너무 길 때 이렇게 뜨는 경우가 있네요..? `김성현`
    - ‘a’ 672글자입니다 영어로 띄어쓰기 없는 한 단어인데 길 때 이렇게 뜨는 거 같아요
- 댓글도 영어 띄워쓰기 없이 길게 쓰니까 밖으로 삐져나가네요 `김성현`

긴 문자열 예시
```
asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa
```

## ☑️ 체크 사항

- [x] 게시글의 본문에 하나의 단어이지만, 엄청 긴 경우에도 줄 바꿈이 잘 되는지
- [x] 댓글의 줄 바꿈이 잘 되는지
- [x] 대댓글의 줄 바꿈이 잘 되는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
