### PR TITLE
[KK-63] 강의평 페이지 반응형 대응

### DIFF
--- a/src/components/courseReview/InfoDetail.tsx
+++ b/src/components/courseReview/InfoDetail.tsx
@@ -43,11 +43,11 @@ const InfoDetail = ({ attendance, classLevel, teamProject, amountLearned, teachi
         css({
           display: 'flex',
           flexDir: 'column',
-          gap: 5,
+          gap: { base: 5, smDown: 10 },
           rounded: 10,
           px: 5,
           pt: 5,
-          pb: 11,
+          pb: { base: 11, smDown: 5 },
         }),
         shadow(),
       )}
@@ -57,7 +57,7 @@ const InfoDetail = ({ attendance, classLevel, teamProject, amountLearned, teachi
         <span className={StateStyle}>{attendanceArray[attendance]}</span>
       </div>
       <div className={css({ display: 'flex', flexDir: 'column', gap: 10 })}>
-        <div className={css({ display: 'flex' })}>
+        <div className={css({ display: 'flex', flexDir: { base: 'row', smDown: 'column' }, smDown: { gap: 10 } })}>
           <div className={ScoreBoxStyle}>
             <div className={LabelStyle}>Class Level</div>
             <div className={css({ display: 'flex', gap: 2.5, alignItems: 'center' })}>
@@ -73,7 +73,7 @@ const InfoDetail = ({ attendance, classLevel, teamProject, amountLearned, teachi
             </div>
           </div>
         </div>
-        <div className={css({ display: 'flex' })}>
+        <div className={css({ display: 'flex', flexDir: { base: 'row', smDown: 'column' }, smDown: { gap: 10 } })}>
           <div className={ScoreBoxStyle}>
             <div className={LabelStyle}>Amount Learned</div>
             <div className={css({ display: 'flex', gap: 2.5, alignItems: 'center' })}>

--- a/src/components/courseReview/ReviewBanner.tsx
+++ b/src/components/courseReview/ReviewBanner.tsx
@@ -9,13 +9,13 @@ const ReviewBanner = ({ title }: ReviewBannerProps) => {
       className={css({
         h: 35,
         w: '100%',
-        pl: 64,
         display: 'flex',
         alignItems: 'center',
         color: 'black.2',
         fontWeight: 800,
-        fontSize: 32,
+        fontSize: { base: 32, mdDown: 26, xsDown: 22 },
         bgColor: 'bg.gray',
+        px: { base: 60, lgDown: 26, mdDown: 5 },
       })}
     >
       {title}

--- a/src/components/courseReview/ReviewChoiceChips.tsx
+++ b/src/components/courseReview/ReviewChoiceChips.tsx
@@ -78,7 +78,7 @@ const ReviewChoiceChips = ({ title, category, options }: ReviewChoiceChipsProps)
                 <button
                   type="button"
                   className={cva({
-                    base: { fontSize: 18, cursor: 'pointer' },
+                    base: { fontSize: { base: 18, mdDown: 16, smDown: 14, xsDown: 12 }, cursor: 'pointer' },
                     variants: { selected: { true: { color: 'black.2' } } },
                   })({ selected: watch(category) === index })}
                   onClick={() => setValue<string>(category, index)}

--- a/src/components/courseReview/ReviewHeader.tsx
+++ b/src/components/courseReview/ReviewHeader.tsx
@@ -22,19 +22,28 @@ const ReviewHeader = ({ courseCode, courseName, prof }: ReviewHeaderProps) => {
   )
 
   return (
-    <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 5 })}>
+    <div
+      className={css({
+        display: 'flex',
+        justifyContent: { base: 'space-between', mdDown: 'flex-start' },
+        alignItems: { base: 'center', mdDown: 'flex-start' },
+        gap: { base: 5, mdDown: 2 },
+        flexDir: { base: 'row', mdDown: 'column' },
+      })}
+    >
       <div
         className={css({
           display: 'flex',
           flexDir: 'column',
           gap: 1,
           overflow: 'hidden',
+          mdDown: { w: 'full' },
         })}
       >
         <span
           className={css({
             fontWeight: 600,
-            fontSize: 26,
+            fontSize: { base: 26, smDown: 20 },
             color: 'black.2',
             overflow: 'hidden',
             whiteSpace: 'nowrap',
@@ -45,7 +54,7 @@ const ReviewHeader = ({ courseCode, courseName, prof }: ReviewHeaderProps) => {
         </span>
         <span
           className={css({
-            fontSize: 18,
+            fontSize: { base: 18, smDown: 16 },
             color: 'darkGray.2',
             overflow: 'hidden',
             whiteSpace: 'nowrap',

--- a/src/components/courseReview/ReviewHeader.tsx
+++ b/src/components/courseReview/ReviewHeader.tsx
@@ -46,7 +46,7 @@ const ReviewHeader = ({ courseCode, courseName, prof }: ReviewHeaderProps) => {
             fontSize: { base: 26, smDown: 20 },
             color: 'black.2',
             overflow: 'hidden',
-            whiteSpace: 'nowrap',
+            lineClamp: 2,
             textOverflow: 'ellipsis',
           })}
         >

--- a/src/components/courseReview/ReviewHeader.tsx
+++ b/src/components/courseReview/ReviewHeader.tsx
@@ -26,11 +26,9 @@ const ReviewHeader = ({ courseCode, courseName, prof }: ReviewHeaderProps) => {
       <div
         className={css({
           display: 'flex',
-          gap: 5,
-          alignItems: 'center',
+          flexDir: 'column',
+          gap: 1,
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
         })}
       >
         <span

--- a/src/components/courseReview/TotalRate.tsx
+++ b/src/components/courseReview/TotalRate.tsx
@@ -22,13 +22,21 @@ const TotalRate = ({ totalRate, reviewCount, courseCode, prof }: TotalRateProps)
           rounded: 10,
           px: 5,
           pt: 5,
-          pb: 10,
+          pb: { base: 10, smDown: 5 },
         }),
         shadow(),
       )}
     >
       <div className={css({ fontWeight: 700, color: 'lightGray.1', fontSize: 14 })}>Course Review Total Rate</div>
-      <div className={css({ display: 'flex', alignItems: 'center', justifyContent: 'space-between' })}>
+      <div
+        className={css({
+          display: 'flex',
+          flexDir: { base: 'row', smDown: 'column' },
+          alignItems: { base: 'center', smDown: 'flex-start' },
+          justifyContent: { base: 'space-between', smDown: 'flex-start' },
+          smDown: { gap: 5 },
+        })}
+      >
         <div className={css({ display: 'flex', gap: 2.5, color: 'darkGray.2', alignItems: 'center' })}>
           <span className={css({ fontSize: 18 })}>{totalRate.toFixed(1)}</span>
           <CookiesRate rate={totalRate} size={18} gap={4} />

--- a/src/pages/CourseReviewPage/CourseInfoPage.tsx
+++ b/src/pages/CourseReviewPage/CourseInfoPage.tsx
@@ -10,7 +10,7 @@ const CourseInfoPage = () => {
   const data = useAtomValue(courseSummary)
 
   return (
-    <div className={css({ flexGrow: 1, display: 'flex', flexDir: 'column', gap: 10, maxW: '820px' })}>
+    <div className={css({ flexGrow: 1, display: 'flex', flexDir: 'column', gap: 10, maxW: '820px', minW: 0 })}>
       <ReviewHeader courseCode={data.courseCode} courseName={data.courseName} prof={data.prof} />
       <TotalRate
         totalRate={data.totalRate}

--- a/src/pages/CourseReviewPage/ReviewPage.tsx
+++ b/src/pages/CourseReviewPage/ReviewPage.tsx
@@ -79,7 +79,16 @@ const ReviewPage = () => {
   }, [isError, error, isFetching, navigate])
 
   return (
-    <div className={css({ flexGrow: 1, display: 'flex', flexDir: 'column', gap: 12, maxW: '820px' })}>
+    <div
+      className={css({
+        flexGrow: 1,
+        display: 'flex',
+        flexDir: 'column',
+        minW: 0,
+        gap: 12,
+        maxW: '820px',
+      })}
+    >
       <div className={css({ display: 'flex', flexDir: 'column', gap: 2.5 })}>
         <div className={css({ display: 'flex', gap: 2.5, color: 'darkGray.2', alignItems: 'center' })}>
           <span className={css({ fontSize: 18 })}>{totalData.totalRate.toFixed(1)}</span>
@@ -91,7 +100,7 @@ const ReviewPage = () => {
       <div className={css({ display: 'flex', flexDir: 'column', gap: 5 })}>
         <div className={css({ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 7 })}>
           <span className={css({ display: 'flex', gap: 4, color: 'darkGray.2', fontSize: 18, alignItems: 'center' })}>
-            Filtering
+            <span className={css({ smDown: { display: 'none' } })}>Filtering</span>
             <span className={css({ display: 'flex', gap: 2.5 })}>
               <button
                 className={CriteriaBtnStyle({ selected: criteria === 'createdAt' })}

--- a/src/pages/CourseReviewPage/WriteReviewPage.tsx
+++ b/src/pages/CourseReviewPage/WriteReviewPage.tsx
@@ -82,7 +82,7 @@ const WriteReviewPage = () => {
             flexGrow: 1,
             minW: 0,
             rounded: 10,
-            p: 5,
+            p: { base: 5, smDown: 3.5, xsDown: 2 },
             pb: 10,
             display: 'flex',
             flexDir: 'column',
@@ -92,12 +92,18 @@ const WriteReviewPage = () => {
         )}
         onSubmit={methods.handleSubmit(onSubmit)}
       >
-        <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 3 })}>
+        <div
+          className={css({
+            display: 'flex',
+            flexDir: 'column',
+            gap: 3,
+          })}
+        >
           <div
             className={css({
               display: 'flex',
-              gap: 5,
-              alignItems: 'center',
+              flexDir: 'column',
+              gap: 1,
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
               overflow: 'hidden',
@@ -106,7 +112,7 @@ const WriteReviewPage = () => {
             <span
               className={css({
                 fontWeight: 600,
-                fontSize: 26,
+                fontSize: { base: 26, mdDown: 20, smDown: 16 },
                 color: 'black.2',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -117,16 +123,14 @@ const WriteReviewPage = () => {
             </span>
             <span
               className={css({
-                fontSize: 18,
+                fontSize: { base: 18, mdDown: 16, smDown: 14 },
                 color: 'darkGray.2',
               })}
             >
               {prof}
             </span>
           </div>
-          <div className={css({ flexBasis: 68, flexShrink: 0 })}>
-            <Dropdown dropdownList={semesterList} curIndex={curSemester} setCurIndex={setCurSemester} />
-          </div>
+          <Dropdown dropdownList={semesterList} curIndex={curSemester} setCurIndex={setCurSemester} />
         </div>
         <div className={css({ display: 'flex', flexDir: 'column', gap: 5, alignItems: 'flex-start' })}>
           <ReviewTotalRate />

--- a/src/pages/CourseReviewPage/index.tsx
+++ b/src/pages/CourseReviewPage/index.tsx
@@ -27,9 +27,18 @@ const CourseReviewPage = () => {
   return (
     <div>
       <ReviewBanner title={curPathRoot === 'info' ? 'Course Information' : 'Course Review'} />
-      <div className={css({ px: 64, py: 12, display: 'flex', gap: 5, alignItems: 'flex-start' })}>
+      <div
+        className={css({
+          px: { base: 60, lgDown: 26, mdDown: 5 },
+          py: { base: 12, smDown: 5 },
+          display: 'flex',
+          gap: 5,
+          alignItems: { base: 'flex-start', mdDown: 'stretch' },
+          flexDir: { base: 'row', mdDown: 'column' },
+        })}
+      >
         <button
-          className={cx(FriendPageBtnStyle({ prev: true }), css({ flexShrink: 0 }))}
+          className={cx(FriendPageBtnStyle({ prev: true }), css({ flexShrink: 0, mdDown: { w: 47 } }))}
           onClick={() => {
             if (curPathRoot === 'info') {
               navigate('/timetable')


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- 강의명과 교수명이 잘려요. 특히 한국인 교수님이 대부분인데 대부분 성에서 잘려서 수정이 필요해요 `강경아`
    - 강의명과 교수님을 다른 줄에서 보여주면 될 것 같아요
- 좁은 화면에 대해 강의평 페이지가 대응하지 않아요 `하승준`

### After
<img width="200" alt="Screenshot 2024-10-06 at 11 35 50 AM" src="https://github.com/user-attachments/assets/03ba81bf-1264-4978-93f6-7fa662e73fa7">
<img width="200" alt="Screenshot 2024-10-06 at 11 35 57 AM" src="https://github.com/user-attachments/assets/53fdbd51-47d3-4577-9bd1-cef6b7edd51b">
<img width="200" alt="Screenshot 2024-10-06 at 11 36 06 AM" src="https://github.com/user-attachments/assets/bd34bce1-c618-46b1-bbe0-0f95304beeee">


## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 강의평 페이지에서 긴 강의명과 교수명에 대해 잘리지 않는지 (강의명과 교수명이 다른 줄에 표시되는지)
- [x] 강의평 요약, 강의평 리스트, 세부 강의평, 강의평 작성 페이지 각각에서 화면 사이징에 따라 깨지는 부분이 있는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

- #29 