### PR TITLE
[KK-70] fix: blob의 타입을 "image/jpeg" 로 지정

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-router-dom": "^6.22.3",
     "react-select": "^5.8.0",
     "react-textarea-autosize": "^8.5.3",
+    "sonner": "^1.5.0",
     "ts-pattern": "^5.3.1",
     "zod": "^3.23.8"
   },

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -16,6 +16,7 @@ import {
   tagRecipe,
   textStyles,
   sheetRecipe,
+  toastRecipe,
 } from './src/lib/recipes/index'
 import { tokenToRem } from './src/lib/constants/tokenToRem'
 
@@ -46,6 +47,7 @@ export default defineConfig({
         carouselButton: carouselButtonRecipe,
         postCard: postCardRecipe,
         sheet: sheetRecipe,
+        toast: toastRecipe,
       },
       slotRecipes: {
         menubar: menubar,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useRoutes } from 'react-router-dom'
+import { Toaster } from 'sonner'
 
 import routes from '@/lib/router/router'
 import AmplitudeProvider from '@/util/AmplitudeProvider'
@@ -24,6 +25,7 @@ function App() {
       <AuthProvider />
       <AmplitudeProvider />
       <ScrollToTop />
+      <Toaster position="top-right" />
       {router}
     </QueryClientProvider>
   )

--- a/src/components/community/post/ImageInputSection.tsx
+++ b/src/components/community/post/ImageInputSection.tsx
@@ -1,8 +1,10 @@
 import { css } from '@styled-system/css'
 import { AnimatePresence, motion } from 'framer-motion'
 import { CircleX, Paperclip, Plus } from 'lucide-react'
+import { useParams } from 'react-router-dom'
 
 import { Checkbox } from '@/components/ui/checkbox'
+import { ActionType } from '@/types/post'
 
 interface ImageInputSectionProps {
   files: File[] | null
@@ -18,6 +20,7 @@ const ImageInputSection = ({
   anonymous,
   handleAnonymous,
 }: ImageInputSectionProps) => {
+  const { type } = useParams() as { type: ActionType }
   return (
     <div className={css({ display: 'flex', w: 'full', flexDir: 'column', alignItems: 'flex-start', gap: '50px' })}>
       <div
@@ -50,8 +53,15 @@ const ImageInputSection = ({
             disabled={files ? files.length >= 5 : false}
           />
         </label>
-        <div className={css({ display: 'flex', alignItems: 'center', gap: 1.5 })}>
-          <Checkbox checked={anonymous} onCheckedChange={handleAnonymous} />
+        <div
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            visibility: type === 'edit' ? 'hidden' : 'unset',
+          })}
+        >
+          <Checkbox checked={anonymous} onCheckedChange={handleAnonymous} disabled={type === 'edit'} />
           <p className={css({ textStyle: 'heading4_M', color: 'darkGray.2' })}>Anonymous</p>
         </div>
       </div>

--- a/src/components/community/post/PostWriteSection.tsx
+++ b/src/components/community/post/PostWriteSection.tsx
@@ -3,6 +3,7 @@ import { postCard } from '@styled-system/recipes'
 import { useAtom } from 'jotai'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'sonner'
 
 import { usePatchEditPost, usePostCreate } from '@/api/hooks/community'
 import ImageInputSection from '@/components/community/post/ImageInputSection'
@@ -10,6 +11,7 @@ import Dropdown from '@/components/timetable/Dropdown'
 import Button from '@/components/ui/button'
 import NoticeModal from '@/components/ui/modal/NoticeModal'
 import { MemoizedTextAreaAutosize } from '@/components/ui/textarea-autosize'
+import Toast from '@/components/ui/toast'
 import { POST_MESSAGES } from '@/lib/messages/community'
 import { initialPostData, persistedPostData } from '@/lib/store/post'
 import { createFileFromUrl } from '@/util/create-file-from-url'
@@ -40,15 +42,14 @@ const PostWriteSection = () => {
   const { mutate: mutatePost } = usePostCreate()
   const { mutate: mutateEditPost } = usePatchEditPost()
   const navigate = useNavigate()
+
   const handleClick = useCallback(() => {
     if (!titleRef.current || !bodyRef.current) return
     if (!currentIndex) {
-      setAlertMessage(POST_MESSAGES.BOARD_REQUIRED)
-      return handleOpen()
+      return toast.custom(() => <Toast message={POST_MESSAGES.BOARD_REQUIRED} type="warning" />)
     }
     if (!titleRef.current.value || !bodyRef.current.value) {
-      setAlertMessage(POST_MESSAGES.CONTENT_REQUIRED)
-      return handleOpen()
+      return toast.custom(() => <Toast message={POST_MESSAGES.CONTENT_REQUIRED} type="warning" />)
     }
     if (type === 'write') {
       mutatePost(
@@ -61,7 +62,7 @@ const PostWriteSection = () => {
         },
         {
           onSuccess: () => {
-            alert('Post has been successful')
+            toast.custom(() => <Toast message={'Post has been successful'} type="success" />)
             navigate(-1)
           },
         },
@@ -89,7 +90,6 @@ const PostWriteSection = () => {
     anonymous,
     currentIndex,
     files,
-    handleOpen,
     initialData,
     isChanged,
     mutateEditPost,

--- a/src/components/community/post/PostWriteSection.tsx
+++ b/src/components/community/post/PostWriteSection.tsx
@@ -9,14 +9,12 @@ import { usePatchEditPost, usePostCreate } from '@/api/hooks/community'
 import ImageInputSection from '@/components/community/post/ImageInputSection'
 import Dropdown from '@/components/timetable/Dropdown'
 import Button from '@/components/ui/button'
-import NoticeModal from '@/components/ui/modal/NoticeModal'
 import { MemoizedTextAreaAutosize } from '@/components/ui/textarea-autosize'
 import Toast from '@/components/ui/toast'
 import { POST_MESSAGES } from '@/lib/messages/community'
 import { initialPostData, persistedPostData } from '@/lib/store/post'
 import { createFileFromUrl } from '@/util/create-file-from-url'
 import { useFile } from '@/util/useFile'
-import { useModal } from '@/util/useModal'
 
 enum boardConfig {
   main = 0,
@@ -33,12 +31,10 @@ const PostWriteSection = () => {
   const [initialData, setInitialData] = useAtom(persistedPostData)
   const [initialImgFiles, setInitialImgFiles] = useState<File[]>()
   const [currentIndex, setCurIndex] = useState(boardConfig[boardName ?? 'main'])
-  const { isOpen, handleOpen } = useModal(true)
   const { files, isChanged, handleFilesChange, handleFileDelete } = useFile('image', 5, initialImgFiles)
   const titleRef = useRef<HTMLTextAreaElement>(null)
   const bodyRef = useRef<HTMLTextAreaElement>(null)
   const [anonymous, setAnonymous] = useState(initialData ? initialData.user.username === 'Anonymous' : false)
-  const [alertMessage, setAlertMessage] = useState('')
   const { mutate: mutatePost } = usePostCreate()
   const { mutate: mutateEditPost } = usePatchEditPost()
   const navigate = useNavigate()
@@ -231,7 +227,6 @@ const PostWriteSection = () => {
           POST
         </Button>
       </div>
-      <NoticeModal content={alertMessage} isOpen={isOpen} />
     </section>
   )
 }

--- a/src/components/community/post/PostWriteSection.tsx
+++ b/src/components/community/post/PostWriteSection.tsx
@@ -13,6 +13,7 @@ import { MemoizedTextAreaAutosize } from '@/components/ui/textarea-autosize'
 import Toast from '@/components/ui/toast'
 import { POST_MESSAGES } from '@/lib/messages/community'
 import { initialPostData, persistedPostData } from '@/lib/store/post'
+import { ActionType } from '@/types/post'
 import { createFileFromUrl } from '@/util/create-file-from-url'
 import { useFile } from '@/util/useFile'
 
@@ -22,7 +23,6 @@ enum boardConfig {
   question = 2,
   information = 3,
 }
-type ActionType = 'write' | 'edit'
 const PostWriteSection = () => {
   const { boardName, type } = useParams() as {
     boardName: 'main' | 'community' | 'question' | 'information'

--- a/src/components/ui/toast/index.tsx
+++ b/src/components/ui/toast/index.tsx
@@ -1,0 +1,18 @@
+import { css, RecipeVariant } from '@styled-system/css'
+import { toast } from '@styled-system/recipes'
+
+type ToastProps = {
+  message: string
+} & RecipeVariant<typeof toast>
+const Toast = ({ message, type }: ToastProps) => {
+  return (
+    <div className={toast({ type })}>
+      <h3 className={css({ textStyle: 'heading3_L', smDown: { fontSize: '14px' }, lineHeight: '100%' })}>
+        {`${type}`.toUpperCase()}
+      </h3>
+      <p className={css({ textStyle: 'heading4_M', smDown: { fontSize: '13px' }, lineHeight: '100%' })}>{message}</p>
+    </div>
+  )
+}
+
+export default Toast

--- a/src/lib/recipes/index.ts
+++ b/src/lib/recipes/index.ts
@@ -13,6 +13,7 @@ import { shadowRecipe } from '@/lib/recipes/shadow'
 import { sheetRecipe } from '@/lib/recipes/sheet'
 import { tagRecipe } from '@/lib/recipes/tag'
 import { textStyles } from '@/lib/recipes/textStyles'
+import { toastRecipe } from '@/lib/recipes/toast'
 export {
   buttonRecipe,
   labelRecipe,
@@ -29,4 +30,5 @@ export {
   menubar,
   clubTagRecipe,
   sheetRecipe,
+  toastRecipe,
 }

--- a/src/lib/recipes/toast.ts
+++ b/src/lib/recipes/toast.ts
@@ -1,0 +1,44 @@
+import { defineRecipe } from '@pandacss/dev'
+
+export const toastRecipe = defineRecipe({
+  className: 'toast',
+  description: 'Toast',
+  base: {
+    display: 'flex',
+    p: { base: 5, smDown: 3 },
+    flexDir: 'column',
+    rounded: '1.25rem',
+    border: '1px solid white',
+    bgColor: '#F0F0F0',
+    gap: 2.5,
+    w: '23rem',
+    maxH: '5.9375rem',
+  },
+  variants: {
+    type: {
+      default: {
+        bgColor: '#F0F0F0',
+        color: '#4F4F4F',
+        boxShadow: '0px 0px 10px 0px rgba(128, 128, 128, 0.50)',
+      },
+      success: {
+        bgColor: '#DFF0D8',
+        color: '#3C763D',
+        boxShadow: '0px 0px 10px 0px rgba(0, 255, 0, 0.50)',
+      },
+      warning: {
+        bgColor: '#FFFAE9',
+        color: '#8A6D3B',
+        boxShadow: '0px 0px 10px 0px rgba(255, 165, 0, 0.50)',
+      },
+      error: {
+        bgColor: 'red.3',
+        color: 'white',
+        boxShadow: '0px 0px 10px 0px rgba(255, 0, 0, 0.50)',
+      },
+    },
+  },
+  defaultVariants: {
+    type: 'default',
+  },
+})

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,1 @@
+export type ActionType = 'write' | 'edit'

--- a/src/util/create-file-from-url.ts
+++ b/src/util/create-file-from-url.ts
@@ -1,5 +1,5 @@
 export const createFileFromUrl = async (url: string, filename: string) => {
   const response = await fetch(url, { mode: 'cors' })
   const blob = await response.blob()
-  return new File([blob], filename, { type: blob.type })
+  return new File([blob], filename, { type: 'image/jpg' })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,6 +4365,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+sonner@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-1.5.0.tgz#af359f817063318415326b33aab54c5d17c747b7"
+  integrity sha512-FBjhG/gnnbN6FY0jaNnqZOMmB73R+5IiyYAw8yBj7L54ER7HB3fOSE5OFiQiE2iXWxeXKvg6fIP4LtVppHEdJA==
+
 source-map-js@^1.0.2, source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"


### PR DESCRIPTION
## 📌 내용

- 글 수정 시 anonymous 변경도 불가능하도록 막아야 할 것 같아요.
    - anonymous 변경하니 댓글 익명/실명 관련 로직이 꼬여요.
- 사진이 있는 글을 수정할 때 오류가 있어요.
    - 간헐적으로 기존 사진 목록이 뜨지 않는 이슈가 있어요 `강경아`
    - 기존 사진 목록이 뜨더라도, 기존 사진을 삭제하면 편집한 내용이 저장되지 않아요. `강경아`
        - 이미지를 변경할 때 기존 이미지가 서버에서 이미지로 판단이 안되는거같네요 “Only image file can be uploaded!” 이 에러가 계속 뜨는데 기존의 이미지를 불러와서 다시 요청 보내는 부분을 한번 확인해봐야 될 거 같아요 `김성현`
        - 새로 이미지 추가하고 기존 거를 지우면 잘 되는 게 기존 거를 이미지로 인식하지 않는거 같습니다. `김성현`
  
익명성은 글을 수정할 때는 접근을 할 수 없게 막았어요.
사진의 경우 서버에 저장된 사진 URL을 통해 파일 객체를 생성하는데, 이때 
```ts
  return new File([blob], filename, { type: blob.type })
```
이처럼 blob.type으로 생성을 하니 이미지 타입이 생성되지 않고, 백엔드에서는 파일의 헤더의 type이 image로 시작하는 경우에만 accept하고 있어서 수정이 안되는 상황이었어요. 
## ☑️ 체크 사항

- [x] 게시글을 수정할 때 익명 수정 버튼이 안 보이는지
- [x] 한 개 이상 사진이 존재하던 게시글을 수정할 때, 사진을 하나만 삭제해도 게시글 수정이 가능한지

## ❗ Related Issues
