### PR TITLE
[KK-49] feat: username 변경 시 validation check

### DIFF
--- a/src/components/mypage/Contents/PublicProfile.tsx
+++ b/src/components/mypage/Contents/PublicProfile.tsx
@@ -1,7 +1,9 @@
 import { css } from '@styled-system/css'
-import { useCallback, useEffect } from 'react'
+import { CheckCircle2, ShieldAlert } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
+import { useCheckUsernameDuplication } from '@/api/hooks/register'
 import { useDeleteLanguage, usePatchMyProfile, usePostLanguage } from '@/api/hooks/user'
 import { GetMyProfileResponse } from '@/api/types/user'
 import ProfileChangeHeader from '@/components/mypage/ProfileChangeHeader'
@@ -46,7 +48,9 @@ interface PublicProfileProps {
 const PublicProfile = ({
   myProfileData: { username, country, homeUniversity, major, languages },
 }: PublicProfileProps) => {
-  const { register, handleSubmit, setValue, watch } = useForm<PublicProfileForm>()
+  const { register, handleSubmit, setValue, watch, getValues, setError, formState, trigger, clearErrors } =
+    useForm<PublicProfileForm>()
+
   useEffect(() => {
     setValue('username', username)
     setValue('country', country)
@@ -54,14 +58,39 @@ const PublicProfile = ({
     setValue('major', major)
     setValue('languages', languages)
   }, [username, country, homeUniversity, major, languages, setValue])
+  const [usernameValidation, setUsernameValidation] = useState(false)
 
   const { mutate: patchProfile } = usePatchMyProfile()
   const { mutate: addLang } = usePostLanguage()
   const { mutate: deleteLang } = useDeleteLanguage()
+  const { mutate: mutateCheckUsernameDuplication } = useCheckUsernameDuplication()
+
+  const handleUsernameValidCheck = () => {
+    const inputUsername = getValues().username
+    if (username === inputUsername) {
+      setError('username', { message: 'It is the same nickname as your current nickname' })
+      return
+    }
+    trigger('username', { shouldFocus: true })
+    mutateCheckUsernameDuplication(getValues().username, {
+      onSuccess: () => setUsernameValidation(true),
+      onError: () => {
+        setError('username', { message: 'This ID is a duplicate ID' })
+        return
+      },
+    })
+  }
 
   const onSubmit: SubmitHandler<PublicProfileForm> = data => {
+    if (!usernameValidation) {
+      setError('username', { message: 'Please verify your nickname!' }, { shouldFocus: true })
+      return
+    }
     patchProfile(data, {
-      onSuccess: () => alert('Changed successfully!'),
+      onSuccess: () => {
+        alert('Changed successfully!')
+        setUsernameValidation(false)
+      },
     })
     const add = data.languages.filter(lang => !languages.includes(lang))
     const del = languages.filter(lang => !data.languages.includes(lang))
@@ -91,7 +120,41 @@ const PublicProfile = ({
           <div className={css({ display: 'flex', flexDir: 'column', gap: 2.5 })}>
             <div className={ProfileFormWrapper}>
               <span className={ProfileFormTitle}>Username</span>
-              <Input placeholder={username} {...register('username', { required: true })} />
+              <Input
+                placeholder={username}
+                {...register('username', {
+                  required: { value: true, message: 'This field is required' },
+                  maxLength: { value: 10, message: 'username must be at most 10 characters long' },
+                  minLength: { value: 5, message: 'username must be at least 5 characters long' },
+                  onChange: () => {
+                    clearErrors('username')
+                    setUsernameValidation(false)
+                  },
+                })}
+              />
+              <Button
+                variant="input"
+                type="button"
+                disabled={getValues('username') === '' || usernameValidation}
+                onClick={handleUsernameValidCheck}
+              >
+                <p className={css({ textStyle: 'body1_L', lineHeight: '100%', smDown: { fontSize: 12 } })}>Verify</p>
+              </Button>
+            </div>
+            <div className={css({ display: 'flex', px: 1.5, py: 1, gap: 1, alignItems: 'center' })}>
+              {formState.errors.username ? (
+                <>
+                  <ShieldAlert size={16} className={css({ color: 'red.2' })} />
+                  <p className={css({ fontSize: 14, fontWeight: 400 })}>{formState.errors.username.message}</p>
+                </>
+              ) : (
+                usernameValidation && (
+                  <>
+                    <CheckCircle2 size={14} />
+                    <p className={css({ fontSize: 14, fontWeight: 400 })}>available username</p>
+                  </>
+                )
+              )}
             </div>
             <div className={ProfileFormWrapper}>
               <span className={ProfileFormTitle}>Nation</span>

--- a/src/components/mypage/Contents/PublicProfile.tsx
+++ b/src/components/mypage/Contents/PublicProfile.tsx
@@ -117,35 +117,58 @@ const PublicProfile = ({
       <ProfileChangeHeader type="public" />
       <form className={css({ display: 'flex', flexDir: 'column', gap: 25 })} onSubmit={handleSubmit(onSubmit)}>
         <section className={css({ display: 'flex', flexDir: 'column', gap: '50px' })}>
-          <div className={css({ display: 'flex', flexDir: 'column', gap: 2.5 })}>
+          <div
+            className={css({ display: 'flex', flexDir: 'column', gap: 2.5, maxW: { base: '609px', mdDown: '282px' } })}
+          >
             <div className={ProfileFormWrapper}>
               <span className={ProfileFormTitle}>Username</span>
-              <Input
-                placeholder={username}
-                {...register('username', {
-                  required: { value: true, message: 'This field is required' },
-                  maxLength: { value: 10, message: 'username must be at most 10 characters long' },
-                  minLength: { value: 5, message: 'username must be at least 5 characters long' },
-                  onChange: () => {
-                    clearErrors('username')
-                    setUsernameValidation(false)
-                  },
+              <span
+                className={css({
+                  display: 'flex',
+                  alignItems: 'stretch',
+                  gap: 1,
+                  w: { base: '400px', mdDown: '200px' },
                 })}
-              />
-              <Button
-                variant="input"
-                type="button"
-                disabled={getValues('username') === '' || usernameValidation}
-                onClick={handleUsernameValidCheck}
               >
-                <p className={css({ textStyle: 'body1_L', lineHeight: '100%', smDown: { fontSize: 12 } })}>Verify</p>
-              </Button>
+                <Input
+                  placeholder={username}
+                  {...register('username', {
+                    required: { value: true, message: 'This field is required' },
+                    maxLength: { value: 10, message: 'username must be at most 10 characters long' },
+                    minLength: { value: 5, message: 'username must be at least 5 characters long' },
+                    onChange: () => {
+                      clearErrors('username')
+                      setUsernameValidation(false)
+                    },
+                  })}
+                />
+                <Button
+                  variant="input"
+                  type="button"
+                  disabled={getValues('username') === '' || usernameValidation}
+                  onClick={handleUsernameValidCheck}
+                >
+                  <p className={css({ textStyle: 'body1_L', lineHeight: '100%', smDown: { fontSize: 12 } })}>Verify</p>
+                </Button>
+              </span>
             </div>
-            <div className={css({ display: 'flex', px: 1.5, py: 1, gap: 1, alignItems: 'center' })}>
+            <div
+              className={css({
+                display: 'flex',
+                px: 1.5,
+                py: 1,
+                gap: 1,
+                alignItems: 'center',
+                h: '29px',
+                justifyContent: 'flex-end',
+              })}
+            >
               {formState.errors.username ? (
                 <>
                   <ShieldAlert size={16} className={css({ color: 'red.2' })} />
-                  <p className={css({ fontSize: 14, fontWeight: 400 })}>{formState.errors.username.message}</p>
+                  <p className={css({ fontSize: 14, fontWeight: 400, color: 'red.2' })}>
+                    {formState.errors.username.message}
+                  </p>
                 </>
               ) : (
                 usernameValidation && (

--- a/src/components/mypage/Contents/PublicProfile.tsx
+++ b/src/components/mypage/Contents/PublicProfile.tsx
@@ -66,11 +66,6 @@ const PublicProfile = ({
   const { mutate: mutateCheckUsernameDuplication } = useCheckUsernameDuplication()
 
   const handleUsernameValidCheck = () => {
-    const inputUsername = getValues().username
-    if (username === inputUsername) {
-      setError('username', { message: 'It is the same nickname as your current nickname' })
-      return
-    }
     trigger('username', { shouldFocus: true })
     mutateCheckUsernameDuplication(getValues().username, {
       onSuccess: () => setUsernameValidation(true),
@@ -82,7 +77,7 @@ const PublicProfile = ({
   }
 
   const onSubmit: SubmitHandler<PublicProfileForm> = data => {
-    if (!usernameValidation) {
+    if (getValues().username !== username && !usernameValidation) {
       setError('username', { message: 'Please verify your nickname!' }, { shouldFocus: true })
       return
     }
@@ -143,9 +138,12 @@ const PublicProfile = ({
                   })}
                 />
                 <Button
+                  aria-checked={
+                    getValues('username') !== '' && getValues('username') !== username && !usernameValidation
+                  }
                   variant="input"
                   type="button"
-                  disabled={getValues('username') === '' || usernameValidation}
+                  disabled={getValues('username') === '' || getValues('username') === username || usernameValidation}
                   onClick={handleUsernameValidCheck}
                 >
                   <p className={css({ textStyle: 'body1_L', lineHeight: '100%', smDown: { fontSize: 12 } })}>Verify</p>


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- public profile 정보 변경에서 이미 있는 이름 or 삭제된 계정 이름을 입력하면 별다른 알림없이 Save가 안 돼요. **회원가입과 마찬가지로 verify 과정이 필요해요.** - `강경아`
- username이 회원가입 때는 **10글자 제한**이 있는데 마이페이지에서 변경할 때는 제한이 없습니다… - `정연승`

### 변경 내용
- Public Profile 변경 페이지에서 username의 Valid Check(버튼)이 이루어져야 수정할 수 있도록 변경하였습니다
- 5~10자, 공란, 다른 사람이 쓰고 있는 닉네임의 validation이 증명되어야 Save 할 수 있습니다

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [x] Verify를 진행하지 않고 프로필을 변경하려는 시도가 막히는지
- [x] 이미 있는 이름이나 삭제된 계정 이름을 입력했을 때 verify에서 막히는지
- [x] 유저이름을 변경하지 않고, 다른 필드를 변경한 후에도 프로필이 제대로 바뀌는지