### PR TITLE
[KK-76] feat: Image() 요소를 통해 사진의 길이에 따른 높이 조절

### DIFF
--- a/src/components/community/post/PostImgCarousel.tsx
+++ b/src/components/community/post/PostImgCarousel.tsx
@@ -35,7 +35,12 @@ const PostImgCarousel = memo(() => {
     >
       <div className={css({ display: 'flex', backfaceVisibility: 'hidden', w: 'full' })}>
         {postAtomData.imageDirs.map((img, index) => (
-          <PostImgContainer key={img.id} img={img?.imgDir} width={images[index].naturalWidth} />
+          <PostImgContainer
+            key={img.id}
+            img={img?.imgDir}
+            width={images[index].naturalWidth}
+            height={images[index].naturalHeight}
+          />
         ))}
       </div>
       <div className={css({ display: 'flex', pos: 'absolute', px: 5, left: 0 })}>

--- a/src/components/community/post/PostImgCarousel.tsx
+++ b/src/components/community/post/PostImgCarousel.tsx
@@ -11,6 +11,11 @@ import { usePrevNextButtons } from '@/util/usePrevNextButtons'
 
 const PostImgCarousel = memo(() => {
   const postAtomData = useAtomValue(postAtom)
+  const images = postAtomData.imageDirs.map(({ imgDir }) => {
+    const img = new Image()
+    img.src = imgDir
+    return img
+  })
   const [emblaRef, emblaApi] = useEmblaCarousel({ active: postAtomData.imageDirs.length > 1 })
 
   const { onPrevButtonClick, onNextButtonClick, prevBtnDisabled, nextBtnDisabled, currentSlide } =
@@ -29,8 +34,8 @@ const PostImgCarousel = memo(() => {
       ref={emblaRef}
     >
       <div className={css({ display: 'flex', backfaceVisibility: 'hidden', w: 'full' })}>
-        {postAtomData.imageDirs.map(img => (
-          <PostImgContainer key={img.id} img={img?.imgDir} />
+        {postAtomData.imageDirs.map((img, index) => (
+          <PostImgContainer key={img.id} img={img?.imgDir} width={images[index].naturalWidth} />
         ))}
       </div>
       <div className={css({ display: 'flex', pos: 'absolute', px: 5, left: 0 })}>

--- a/src/components/community/post/PostImgContainer.tsx
+++ b/src/components/community/post/PostImgContainer.tsx
@@ -4,8 +4,9 @@ import { memo } from 'react'
 interface PostImgContainerProps {
   img: string
   width: number
+  height: number
 }
-const PostImgContainer = memo(({ img, width }: PostImgContainerProps) => {
+const PostImgContainer = memo(({ img, width, height }: PostImgContainerProps) => {
   return (
     <div className={css({ display: 'flex', w: 'full', flex: '0 0 100%', pos: 'relative' })}>
       <div
@@ -41,7 +42,7 @@ const PostImgContainer = memo(({ img, width }: PostImgContainerProps) => {
           alt="post"
           className={css({
             maxH: 437,
-            h: width < 437 ? 437 : 'auto',
+            h: height < 437 && width < 437 ? 437 : 'auto',
             objectFit: 'cover',
             backdropFilter: 'blur(25px)',
             backdropBlur: '25px',

--- a/src/components/community/post/PostImgContainer.tsx
+++ b/src/components/community/post/PostImgContainer.tsx
@@ -3,8 +3,9 @@ import { memo } from 'react'
 
 interface PostImgContainerProps {
   img: string
+  width: number
 }
-const PostImgContainer = memo(({ img }: PostImgContainerProps) => {
+const PostImgContainer = memo(({ img, width }: PostImgContainerProps) => {
   return (
     <div className={css({ display: 'flex', w: 'full', flex: '0 0 100%', pos: 'relative' })}>
       <div
@@ -39,8 +40,9 @@ const PostImgContainer = memo(({ img }: PostImgContainerProps) => {
           src={img}
           alt="post"
           className={css({
-            h: 437,
-            objectFit: 'obtain',
+            maxH: 437,
+            h: width < 437 ? 437 : 'auto',
+            objectFit: 'cover',
             backdropFilter: 'blur(25px)',
             backdropBlur: '25px',
             backgroundSize: 'cover',

--- a/src/lib/recipes/post-card.ts
+++ b/src/lib/recipes/post-card.ts
@@ -14,6 +14,5 @@ export const postCardRecipe = defineRecipe({
     alignSelf: 'stretch',
     boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.25)',
     rounded: 10,
-    maxW: '51rem',
   },
 })


### PR DESCRIPTION
## 📌 내용

- 가로로 긴 사진도 눌리지 않게 처리해주세요 - `강경아`

사진의 비율에 따라 달라지는 view를 개선했어요.
- 높이가 437px 보다 높은 경우 -> maxH를 설정해 437로 고정
- 세로와 가로 길이 둘 다 437px 보다 작은 경우 `h: height < 437 && width < 437 ? 437 : 'auto'`

## ☑️ 체크 사항

- [x] 이미지들의 비율이 적절하게 반영되어 보이는지

- `/community/community/post/52`
- `/community/community/post/51`
- `/community/community/post/32`

다양한 비율의 사진이 존재하는 게시물이에요.
## ❗ Related Issues
