### PR TITLE
feat: 로그인 이후 deviceCode 받아서 로그아웃에 코드 보내주기

### DIFF
--- a/src/api/hooks/auth.ts
+++ b/src/api/hooks/auth.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 
-import { LoginRequest, LoginResponse } from '@/api/types/auth'
+import { LoginRequest, LoginResponse, LogoutRequest } from '@/api/types/auth'
 import { useAuth } from '@/util/auth/useAuth'
 import { apiInterface } from '@/util/axios/custom-axios'
 
@@ -24,13 +24,14 @@ export const useLogIn = () => {
         accessToken: data.token.accessToken,
         refreshToken: data.token.refreshToken,
         verified: data.verified,
+        deviceCode: data.deviceCode,
       })
     },
   })
 }
 
-const logOut = async () => {
-  const response = await apiInterface.post<null>(`/auth/logout`)
+const logOut = async ({ deviceCode }: LogoutRequest) => {
+  const response = await apiInterface.post<null>(`/auth/logout`, { deviceCode })
   return response.data
 }
 

--- a/src/api/types/auth.ts
+++ b/src/api/types/auth.ts
@@ -4,10 +4,15 @@ export interface LoginResponse {
     refreshToken: string
   }
   verified: boolean
+  deviceCode: string
 }
 
 export interface LoginRequest {
   email: string
   password: string
   keepingLogin: boolean
+}
+
+export interface LogoutRequest {
+  deviceCode: string
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,13 +22,13 @@ const Header = () => {
   const { mutate: mutateSignOut } = useLogOut()
   const innerTabRef = useRef<HTMLDivElement>(null)
   const [isOpen, setIsOpen] = useState(false)
-  const { isAuthenticated, authState } = useAuth()
+  const { isAuthenticated, authState, deviceCode } = useAuth()
   const { isOpen: isModalOpen, handleOpen: handleModalOpen } = useModal(true)
   const [modalContent, setModalContent] = useState(HEADER_MESSAGE.NOT_VERIFIED_USER)
   const navigate = useNavigate()
   const mediaQuery = useMediaQuery('(max-width: 900px)')
   const handleUserButton = useCallback(() => {
-    isAuthenticated ? mutateSignOut() : navigate('/login')
+    isAuthenticated ? mutateSignOut({ deviceCode }) : navigate('/login')
   }, [isAuthenticated, mutateSignOut, navigate])
   const handleOpen = useCallback(() => {
     setIsOpen(prev => !prev)

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,4 +2,5 @@ export interface UserCredential {
   accessToken: string
   refreshToken: string
   verified: boolean
+  deviceCode: string
 }

--- a/src/util/auth/useAuth.ts
+++ b/src/util/auth/useAuth.ts
@@ -8,6 +8,7 @@ import { UserCredential } from '@/types/user'
 export const useAuth = () => {
   const authStore = useStore()
 
+  const [deviceCode, setDeviceCode] = useState<string>(authStore.get(userCredentialAtom)?.deviceCode ?? '')
   const [isAuthenticated, setIsAuthenticated] = useState(!!authStore.get(userCredentialAtom))
   const [authState, setAuthState] = useState(authStore.get(userCredentialAtom)?.verified ?? false)
 
@@ -15,6 +16,7 @@ export const useAuth = () => {
     const userState = authStore.get(userCredentialAtom)
     setIsAuthenticated(!!userState)
     setAuthState(userState?.verified ?? false)
+    setDeviceCode(userState?.deviceCode ?? '')
   }, [authStore])
 
   const unsubscribe = authStore.sub(userCredentialAtom, subscribe)
@@ -40,7 +42,7 @@ export const useAuth = () => {
   console.log('useAuth:', isAuthenticated, authState, new Date().toTimeString())
 
   return useMemo(
-    () => ({ isAuthenticated, authState, signIn, signOut, setVerified }),
-    [isAuthenticated, authState, signIn, signOut, setVerified],
+    () => ({ isAuthenticated, authState, signIn, signOut, setVerified, deviceCode }),
+    [isAuthenticated, authState, signIn, signOut, setVerified, deviceCode],
   )
 }

--- a/src/util/axios/onResponse.ts
+++ b/src/util/axios/onResponse.ts
@@ -9,7 +9,7 @@ const pendingRequests: ((arg: string) => void)[] = []
 export const onResponse = async (
   error: AxiosError,
   refreshToken: string,
-  handleSet: (value: Omit<UserCredential, 'verified'>) => void,
+  handleSet: (value: Omit<UserCredential, 'verified' | 'deviceCode'>) => void,
   handleError: (error: Error) => void,
 ) => {
   const { config, response } = error

--- a/src/util/axios/useAxsiosInterceptor.ts
+++ b/src/util/axios/useAxsiosInterceptor.ts
@@ -14,9 +14,13 @@ export const useAxiosInterceptor = () => {
   const authStore = useStore()
 
   const handleSet = useCallback(
-    (value: Omit<UserCredential, 'verified'>) => {
+    (value: Omit<UserCredential, 'verified' | 'deviceCode'>) => {
       if (!authStore.get(userCredentialAtom)) return
-      authStore.set(userCredentialAtom, { verified: authStore.get(userCredentialAtom)!.verified, ...value })
+      authStore.set(userCredentialAtom, {
+        deviceCode: authStore.get(userCredentialAtom)!.deviceCode,
+        verified: authStore.get(userCredentialAtom)!.verified,
+        ...value,
+      })
     },
     [authStore],
   )


### PR DESCRIPTION
## 📌 내용

로그인 했을 때 res 값으로 deviceCode 받게 해뒀고, authStore에 저장해뒀어요. 토큰 쪽에서는 별도로 활용되지 않고, 오로지 logOut 할 때만 사용되는 로직이에요~!

## ☑️ 체크 사항
- [x] 로그인 할 때 userCredential 에 포함 되어있는지
- [x] 로그아웃 할 때 requestBody로 잘 보내지는지

## ❗ Related Issues
