### PR TITLE
[KK-105]/[#118] fix: 특정 학기의 강의만 검색되도록 수정

### DIFF
--- a/src/api/hooks/course.ts
+++ b/src/api/hooks/course.ts
@@ -12,94 +12,52 @@ import { apiInterface } from '@/util/axios/custom-axios'
 /**
  * 학수번호를 입력하여 강의를 검색합니다.
  */
-export const getByCourseCode = async ({ courseCode, cursorId, year, semester }: GetByCourseCodeRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/search-course-code', {
-    params: {
-      courseCode,
-      cursorId,
-      year,
-      semester,
-    },
-  })
+export const getByCourseCode = async (params: GetByCourseCodeRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/search-course-code', { params })
   return response.data
 }
 /**
  * 전공 과목명을 입력하여 강의를 검색합니다.
  */
-export const getByCourseNameInMajor = async ({
-  courseName,
-  major,
-  cursorId,
-  year,
-  semester,
-}: GetByCourseNameInMajorRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/search-major-course-name', {
-    params: { courseName, major, cursorId, year, semester },
-  })
+export const getByCourseNameInMajor = async (params: GetByCourseNameInMajorRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/search-major-course-name', { params })
   return response.data
 }
 /**d
  * 교양 과목명을 입력하여 강의를 검색합니다.
  */
-export const getByCourseNameInGeneral = async ({
-  courseName,
-  cursorId,
-  year,
-  semester,
-}: GetByCourseNameInGeneralRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/search-general-course-name', {
-    params: { courseName, cursorId, year, semester },
-  })
+export const getByCourseNameInGeneral = async (params: GetByCourseNameInGeneralRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/search-general-course-name', { params })
   return response.data
 }
 /**
  * 전공 과목 담당 교수님 성함을 입력하여 강의를 검색합니다.
  */
-export const getByProfInMajor = async ({ professorName, major, cursorId, year, semester }: GetByProfInMajorRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/search-major-professor-name', {
-    params: { professorName, major, cursorId, year, semester },
-  })
+export const getByProfInMajor = async (params: GetByProfInMajorRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/search-major-professor-name', { params })
   return response.data
 }
 /**
  * 전공 과목 담당 교수님 성함을 입력하여 강의를 검색합니다.
  */
-export const getByProfInGeneral = async ({ professorName, cursorId, year, semester }: GetByProfInGeneralRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/search-general-professor-name', {
-    params: { professorName, cursorId, year, semester },
-  })
+export const getByProfInGeneral = async (params: GetByProfInGeneralRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/search-general-professor-name', { params })
   return response.data
 }
 /**
  * 해당 단과대의 모든 학문의 기초 강의를 조회합니다.
  */
-export const getInAcademicFoundation = async ({
-  college,
-  cursorId,
-  year,
-  semester,
-}: GetInAcademicFoundationRequest) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/academic-foundation', {
-    params: { college, cursorId, year, semester },
-  })
+export const getInAcademicFoundation = async (params: GetInAcademicFoundationRequest) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/academic-foundation', { params })
   return response.data
 }
 
-export const getGeneral = async ({ cursorId, year, semester }: Omit<GetByCourseNameInGeneralRequest, 'courseName'>) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/general', {
-    params: { cursorId, year, semester },
-  })
+export const getGeneral = async (params: Omit<GetByCourseNameInGeneralRequest, 'courseName'>) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/general', { params })
   return response.data
 }
 
-export const getMajor = async ({
-  major,
-  cursorId,
-  year,
-  semester,
-}: Omit<GetByCourseNameInMajorRequest, 'courseName'>) => {
-  const response = await apiInterface.get<GetCourseResponse>('/course/major', {
-    params: { major, cursorId, year, semester },
-  })
+export const getMajor = async (params: Omit<GetByCourseNameInMajorRequest, 'courseName'>) => {
+  const response = await apiInterface.get<GetCourseResponse>('/course/major', { params })
   return response.data
 }

--- a/src/api/hooks/course.ts
+++ b/src/api/hooks/course.ts
@@ -12,11 +12,13 @@ import { apiInterface } from '@/util/axios/custom-axios'
 /**
  * 학수번호를 입력하여 강의를 검색합니다.
  */
-export const getByCourseCode = async ({ courseCode, cursorId }: GetByCourseCodeRequest) => {
+export const getByCourseCode = async ({ courseCode, cursorId, year, semester }: GetByCourseCodeRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/search-course-code', {
     params: {
       courseCode,
       cursorId,
+      year,
+      semester,
     },
   })
   return response.data
@@ -24,59 +26,80 @@ export const getByCourseCode = async ({ courseCode, cursorId }: GetByCourseCodeR
 /**
  * 전공 과목명을 입력하여 강의를 검색합니다.
  */
-export const getByCourseNameInMajor = async ({ courseName, major, cursorId }: GetByCourseNameInMajorRequest) => {
+export const getByCourseNameInMajor = async ({
+  courseName,
+  major,
+  cursorId,
+  year,
+  semester,
+}: GetByCourseNameInMajorRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/search-major-course-name', {
-    params: { courseName, major, cursorId },
+    params: { courseName, major, cursorId, year, semester },
   })
   return response.data
 }
 /**d
  * 교양 과목명을 입력하여 강의를 검색합니다.
  */
-export const getByCourseNameInGeneral = async ({ courseName, cursorId }: GetByCourseNameInGeneralRequest) => {
+export const getByCourseNameInGeneral = async ({
+  courseName,
+  cursorId,
+  year,
+  semester,
+}: GetByCourseNameInGeneralRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/search-general-course-name', {
-    params: { courseName, cursorId },
+    params: { courseName, cursorId, year, semester },
   })
   return response.data
 }
 /**
  * 전공 과목 담당 교수님 성함을 입력하여 강의를 검색합니다.
  */
-export const getByProfInMajor = async ({ professorName, major, cursorId }: GetByProfInMajorRequest) => {
+export const getByProfInMajor = async ({ professorName, major, cursorId, year, semester }: GetByProfInMajorRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/search-major-professor-name', {
-    params: { professorName, major, cursorId },
+    params: { professorName, major, cursorId, year, semester },
   })
   return response.data
 }
 /**
  * 전공 과목 담당 교수님 성함을 입력하여 강의를 검색합니다.
  */
-export const getByProfInGeneral = async ({ professorName, cursorId }: GetByProfInGeneralRequest) => {
+export const getByProfInGeneral = async ({ professorName, cursorId, year, semester }: GetByProfInGeneralRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/search-general-professor-name', {
-    params: { professorName, cursorId },
+    params: { professorName, cursorId, year, semester },
   })
   return response.data
 }
 /**
  * 해당 단과대의 모든 학문의 기초 강의를 조회합니다.
  */
-export const getInAcademicFoundation = async ({ college, cursorId }: GetInAcademicFoundationRequest) => {
+export const getInAcademicFoundation = async ({
+  college,
+  cursorId,
+  year,
+  semester,
+}: GetInAcademicFoundationRequest) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/academic-foundation', {
-    params: { college, cursorId },
+    params: { college, cursorId, year, semester },
   })
   return response.data
 }
 
-export const getGeneral = async ({ cursorId }: Pick<GetByCourseNameInGeneralRequest, 'cursorId'>) => {
+export const getGeneral = async ({ cursorId, year, semester }: Omit<GetByCourseNameInGeneralRequest, 'courseName'>) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/general', {
-    params: { cursorId },
+    params: { cursorId, year, semester },
   })
   return response.data
 }
 
-export const getMajor = async ({ major, cursorId }: Omit<GetByCourseNameInMajorRequest, 'courseName'>) => {
+export const getMajor = async ({
+  major,
+  cursorId,
+  year,
+  semester,
+}: Omit<GetByCourseNameInMajorRequest, 'courseName'>) => {
   const response = await apiInterface.get<GetCourseResponse>('/course/major', {
-    params: { major, cursorId },
+    params: { major, cursorId, year, semester },
   })
   return response.data
 }

--- a/src/api/types/course.ts
+++ b/src/api/types/course.ts
@@ -1,8 +1,7 @@
 import { SearchedCourse } from '@/types/course'
 import { SemesterType } from '@/types/timetable'
 
-export interface GetByCourseCodeRequest {
-  courseCode: string
+interface GetCourseRequestWithSemester {
   cursorId?: number
   year: string
   semester: SemesterType
@@ -14,37 +13,26 @@ export interface GetCourseResponse {
   data: SearchedCourse[]
 }
 
-export interface GetByCourseNameInMajorRequest {
-  major: string
-  courseName: string
-  cursorId?: number
-  year: string
-  semester: SemesterType
+export interface GetByCourseCodeRequest extends GetCourseRequestWithSemester {
+  courseCode: string
 }
 
-export interface GetByCourseNameInGeneralRequest {
+export interface GetByCourseNameInMajorRequest extends GetCourseRequestWithSemester {
+  major: string
   courseName: string
-  cursorId?: number
-  year: string
-  semester: SemesterType
 }
 
-export interface GetByProfInMajorRequest {
+export interface GetByCourseNameInGeneralRequest extends GetCourseRequestWithSemester {
+  courseName: string
+}
+
+export interface GetByProfInMajorRequest extends GetCourseRequestWithSemester {
   major: string
   professorName: string
-  cursorId?: number
-  year: string
-  semester: SemesterType
 }
-export interface GetByProfInGeneralRequest {
+export interface GetByProfInGeneralRequest extends GetCourseRequestWithSemester {
   professorName: string
-  cursorId?: number
-  year: string
-  semester: SemesterType
 }
-export interface GetInAcademicFoundationRequest {
+export interface GetInAcademicFoundationRequest extends GetCourseRequestWithSemester {
   college: string
-  cursorId?: number
-  year: string
-  semester: SemesterType
 }

--- a/src/api/types/course.ts
+++ b/src/api/types/course.ts
@@ -3,6 +3,8 @@ import { SearchedCourse } from '@/types/course'
 export interface GetByCourseCodeRequest {
   courseCode: string
   cursorId?: number
+  year: string
+  semester: number
 }
 
 export interface GetCourseResponse {
@@ -15,23 +17,33 @@ export interface GetByCourseNameInMajorRequest {
   major: string
   courseName: string
   cursorId?: number
+  year: string
+  semester: number
 }
 
 export interface GetByCourseNameInGeneralRequest {
   courseName: string
   cursorId?: number
+  year: string
+  semester: number
 }
 
 export interface GetByProfInMajorRequest {
   major: string
   professorName: string
   cursorId?: number
+  year: string
+  semester: number
 }
 export interface GetByProfInGeneralRequest {
   professorName: string
   cursorId?: number
+  year: string
+  semester: number
 }
 export interface GetInAcademicFoundationRequest {
   college: string
   cursorId?: number
+  year: string
+  semester: number
 }

--- a/src/api/types/course.ts
+++ b/src/api/types/course.ts
@@ -1,10 +1,11 @@
 import { SearchedCourse } from '@/types/course'
+import { SemesterType } from '@/types/timetable'
 
 export interface GetByCourseCodeRequest {
   courseCode: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }
 
 export interface GetCourseResponse {
@@ -18,14 +19,14 @@ export interface GetByCourseNameInMajorRequest {
   courseName: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }
 
 export interface GetByCourseNameInGeneralRequest {
   courseName: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }
 
 export interface GetByProfInMajorRequest {
@@ -33,17 +34,17 @@ export interface GetByProfInMajorRequest {
   professorName: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }
 export interface GetByProfInGeneralRequest {
   professorName: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }
 export interface GetInAcademicFoundationRequest {
   college: string
   cursorId?: number
   year: string
-  semester: number
+  semester: SemesterType
 }

--- a/src/api/types/courseReview.ts
+++ b/src/api/types/courseReview.ts
@@ -58,7 +58,7 @@ export type GetMyReviewResponse = {
   textReview: string
   professorName: string
   year: string
-  semester: string
+  semester: SemesterType
   courseCode: string
   userId: number
 }[]

--- a/src/api/types/friends.ts
+++ b/src/api/types/friends.ts
@@ -1,5 +1,6 @@
 import { CharacterType } from '@/types/community'
 import { FriendInterface, friendStatusType } from '@/types/friends'
+import { SemesterType } from '@/types/timetable'
 
 export interface GetFriendListRequest {
   keyword: string | null
@@ -38,5 +39,5 @@ export interface PatchFriendshipRequestRequest {
 export interface GetFriendTimetableRequest {
   username: string
   year: string
-  semester: string
+  semester: SemesterType
 }

--- a/src/components/calendar/AcademicCalendar.tsx
+++ b/src/components/calendar/AcademicCalendar.tsx
@@ -18,7 +18,7 @@ const AcademicCalendar = ({ data, semester }: AcademicCalendarProps) => {
           className={cva({
             base: { display: 'flex', borderBottom: '2px solid {colors.darkGray.2}' },
             variants: { isStart: { true: { borderTop: '2px solid {colors.darkGray.2}' } } },
-          })({ isStart: (semester === 'Spring' && month === 2) || (semester === 'Fall' && month === 8) })}
+          })({ isStart: (semester === 1 && month === 2) || (semester === 3 && month === 8) })}
         >
           <div
             className={css({

--- a/src/components/courseReview/Review.tsx
+++ b/src/components/courseReview/Review.tsx
@@ -2,11 +2,13 @@ import { css, cx } from '@styled-system/css'
 import { shadow } from '@styled-system/recipes'
 
 import CookiesRate from '@/components/courseReview/CookiesRate'
+import { SemesterType } from '@/types/timetable'
+import { numberToSemester } from '@/util/timetableUtil'
 
 interface ReviewProps {
   courseName: string
   year: string
-  semester: string
+  semester: SemesterType
   rate: number
   text: string
 }
@@ -28,7 +30,7 @@ const Review = ({ courseName, year, semester, rate, text }: ReviewProps) => {
     >
       <div className={css({ color: 'black.2', fontSize: { base: 26, mdDown: 16 }, fontWeight: 600 })}>{courseName}</div>
       <div className={css({ fontSize: 14, fontWeight: 700, color: 'lightGray.1' })}>
-        {year} {semester} semester
+        {year} {numberToSemester[semester]} semester
       </div>
       <div className={css({ display: 'flex', gap: 2.5, color: 'darkGray.2', alignItems: 'center' })}>
         <span className={css({ fontSize: 18 })}>{rate.toFixed(1)}</span>

--- a/src/components/courseReview/ReviewCard.tsx
+++ b/src/components/courseReview/ReviewCard.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom'
 import CookiesRate from '@/components/courseReview/CookiesRate'
 import { courseSummary } from '@/lib/store/review'
 import { ReviewType } from '@/types/review'
+import { numberToSemester } from '@/util/timetableUtil'
 
 interface ReviewCardProps {
   data: ReviewType
@@ -16,7 +17,7 @@ const ReviewCard = ({ data }: ReviewCardProps) => {
   return (
     <div className={cx(shadow(), css({ display: 'flex', gap: 5, flexDir: 'column', rounded: 10, p: 5 }))}>
       <div className={css({ fontSize: 14, fontWeight: 700, color: 'lightGray.1' })}>
-        {data.year} {data.semester} semester
+        {data.year} {numberToSemester[data.semester]} semester
       </div>
       <div className={css({ display: 'flex', alignItems: 'center', justifyContent: 'space-between' })}>
         <div className={css({ display: 'flex', gap: 2.5, color: 'darkGray.2', alignItems: 'center' })}>

--- a/src/components/timetable/Friend/FriendTimetable.tsx
+++ b/src/components/timetable/Friend/FriendTimetable.tsx
@@ -5,12 +5,13 @@ import { useGetFriendTimetable } from '@/api/hooks/friends'
 import LectureGrid from '@/components/timetable/Grid/LectureGrid'
 import { TimeCell } from '@/components/timetable/Grid/TimetableLayout'
 import NullTimetable from '@/components/timetable/NullTimetable'
-import { getWeeknTimeList } from '@/util/timetableUtil'
+import { SemesterType } from '@/types/timetable'
+import { getWeeknTimeList, numberToSemester } from '@/util/timetableUtil'
 
 interface TimetableProps {
   user: string
   year: string
-  semester: string
+  semester: SemesterType
 }
 
 const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year, semester }, ref) => {
@@ -38,7 +39,7 @@ const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year
       >
         <div className={css({ display: 'flex', flexDir: 'row', gap: 2.5, alignItems: 'center' })}>
           <div className={css({ color: 'darkGray.1', fontSize: 20, fontWeight: 700, whiteSpace: 'nowrap' })}>
-            {`${year} ${semester} semester`}
+            {`${year} ${numberToSemester[semester]} semester`}
           </div>
           <div
             className={css({

--- a/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
@@ -66,6 +66,14 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
   })
 
   useEffect(() => {
+    setQuery(prevQuery => ({
+      ...prevQuery,
+      year,
+      semester,
+    }))
+  }, [year, semester])
+
+  useEffect(() => {
     setTimeout(() => {
       scrollSectionRef.current && scrollSectionRef.current.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
     }, 100)

--- a/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@styled-system/css'
 import { isAxiosError } from 'axios'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { match } from 'ts-pattern'
 
@@ -10,7 +10,7 @@ import ClassSelectModal from '@/components/timetable/LectureBottomSheet/AddClass
 import FilterSelector from '@/components/timetable/LectureBottomSheet/AddClass/FilterSelector'
 import SearchLectureCard from '@/components/timetable/LectureBottomSheet/AddClass/SearchLectureCard'
 import SearchBox from '@/components/timetable/SearchBox'
-import { FilterType } from '@/types/timetable'
+import { FilterType, SemesterType } from '@/types/timetable'
 import { filterTypeMap } from '@/util/timetableUtil'
 import { useCourseSearch, useCourseSearchProps } from '@/util/useCourseSearch'
 import useIntersect from '@/util/useIntersect'
@@ -26,18 +26,24 @@ const SearchMessageStyle = css({
   fontWeight: 600,
 })
 
-const initialQuery: useCourseSearchProps = {
-  category: 'All Class',
-  filter: 'code',
-  queryKeyword: '',
-  classification: null,
-}
-
 interface AddClassProps {
   timetableId: number
+  year: string
+  semester: SemesterType
 }
-const AddClass = ({ timetableId }: AddClassProps) => {
+const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
   const scrollSectionRef = useRef<HTMLDivElement>(null)
+  const initialQuery: useCourseSearchProps = useMemo(
+    () => ({
+      category: 'All Class',
+      filter: 'code',
+      queryKeyword: '',
+      classification: null,
+      year,
+      semester,
+    }),
+    [year, semester],
+  )
 
   const [isSearchAvailable, setIsSearchAvailable] = useState(true)
   // 검색 Filter
@@ -99,7 +105,7 @@ const AddClass = ({ timetableId }: AddClassProps) => {
         }
       }
     },
-    [setCurCategory, setCurClassification, setIsModalOpen],
+    [setCurCategory, setCurClassification, setIsModalOpen, initialQuery],
   )
 
   const handleMajorBtn = useCallback(
@@ -115,6 +121,8 @@ const AddClass = ({ timetableId }: AddClassProps) => {
           filter: 'course',
           category: 'Academic Foundations',
           classification,
+          year,
+          semester,
         })
       } else {
         setQuery({
@@ -122,12 +130,14 @@ const AddClass = ({ timetableId }: AddClassProps) => {
           filter: 'course',
           category: 'Major',
           classification,
+          year,
+          semester,
         })
         setIsSearchAvailable(true)
         setCurFilter('course')
       }
     },
-    [curCategory],
+    [curCategory, year, semester],
   )
 
   const handleFilterSelector = useCallback(
@@ -150,11 +160,13 @@ const AddClass = ({ timetableId }: AddClassProps) => {
               filter: targetFilter,
               category: categoryList[curCategory],
               classification: curClassification,
+              year,
+              semester,
             })
           }
         })
     },
-    [curCategory, curClassification],
+    [curCategory, curClassification, year, semester, initialQuery],
   )
 
   const handleSearchBoxOnSubmit = useCallback(
@@ -164,9 +176,11 @@ const AddClass = ({ timetableId }: AddClassProps) => {
         filter: curFilter,
         category: categoryList[curCategory],
         classification: curClassification,
+        year,
+        semester,
       })
     },
-    [curFilter, curCategory, curClassification],
+    [curFilter, curCategory, curClassification, year, semester],
   )
 
   const handleQuitModal = useCallback(() => {

--- a/src/components/timetable/LectureBottomSheet/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/index.tsx
@@ -9,12 +9,15 @@ import { usePostSchedule } from '@/api/hooks/schedule'
 import AddClass from '@/components/timetable/LectureBottomSheet/AddClass'
 import AddOnMyOwn, { AddOnMyOwnForm } from '@/components/timetable/LectureBottomSheet/AddOnMyOwn'
 import Drawer from '@/components/timetable/LectureBottomSheet/Drawer'
+import { SemesterType } from '@/types/timetable'
 
 interface LectureBottomSheetProps {
   timetableId: number
+  year: string
+  semester: SemesterType
   visible: boolean
 }
-const LectureBottomSheet = ({ timetableId, visible }: LectureBottomSheetProps) => {
+const LectureBottomSheet = ({ timetableId, visible, year, semester }: LectureBottomSheetProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const [sheetState, setSheetState] = useState<'class' | 'schedule' | null>(null)
 
@@ -99,7 +102,7 @@ const LectureBottomSheet = ({ timetableId, visible }: LectureBottomSheetProps) =
           {sheetState === 'schedule' ? (
             <AddOnMyOwn submitHandler={addOnMyOwnHandler} />
           ) : (
-            <AddClass timetableId={timetableId} />
+            <AddClass timetableId={timetableId} year={year} semester={semester} />
           )}
         </div>
       </motion.div>

--- a/src/components/timetable/index.tsx
+++ b/src/components/timetable/index.tsx
@@ -7,6 +7,7 @@ import TimetableLayout from '@/components/timetable/Grid/TimetableLayout'
 import OptionModal from '@/components/timetable/Modal/OptionModal'
 import { isBottomSheetVisible } from '@/lib/store/bottomSheet'
 import { GlobalModalStateType, TimetableInfo } from '@/types/timetable'
+import { numberToSemester } from '@/util/timetableUtil'
 
 const optBtn = cva({
   base: {
@@ -108,7 +109,7 @@ const Timetable = forwardRef<HTMLDivElement, TimetableProps>(
           )}
           <div className={css({ display: 'flex', flexDir: 'row', gap: 2.5, alignItems: 'center' })}>
             <div className={css({ color: 'darkGray.1', fontSize: 20, fontWeight: 700, whiteSpace: 'nowrap' })}>
-              {`${year} ${semester} semester`}
+              {`${year} ${numberToSemester[semester]} semester`}
             </div>
             <div
               className={css({

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -16,7 +16,7 @@ const SchedulePage = () => {
   const curSemester = academicSemester[dropdownIndex]
   const { data } = useGetAcademicCalendar({
     year: Number(curSemester.year),
-    semester: curSemester.semester === 'Spring' ? 1 : 2,
+    semester: curSemester.semester === 1 ? 1 : 2,
   })
 
   const setSemesterIndex = useCallback(

--- a/src/pages/TimetablePage/MyTimetablePage.tsx
+++ b/src/pages/TimetablePage/MyTimetablePage.tsx
@@ -90,6 +90,8 @@ const MyTimetablePage = () => {
         {createPortal(
           <LectureBottomSheet
             timetableId={semesterList[curSemester].timetables[curIndex].timetableId}
+            year={semesterList[curSemester].year}
+            semester={semesterList[curSemester].semester}
             visible={isSheetVisible}
           />,
           document.body,

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,4 +1,4 @@
-import { DayType } from '@/types/timetable'
+import { DayType, SemesterType } from '@/types/timetable'
 
 export interface SearchedCourse {
   id: number
@@ -11,7 +11,7 @@ export interface SearchedCourse {
   major: string
   hasExchangeSeat: true
   year: string
-  semester: string
+  semester: SemesterType
   syllabus: string
   totalRate: 0
   details?: courseDetail[]

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,4 +1,5 @@
 import { GetReviewSummaryResponse } from '@/api/types/courseReview'
+import { SemesterType } from '@/types/timetable'
 
 export interface ReviewType {
   id: number
@@ -6,7 +7,7 @@ export interface ReviewType {
   createdAt: string
   reviewer: string
   year: string
-  semester: string
+  semester: SemesterType
   myRecommend: boolean
   recommendCount: number
   text: string

--- a/src/types/timetable.ts
+++ b/src/types/timetable.ts
@@ -2,7 +2,7 @@ export const DayArray = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as con
 
 export type DayType = (typeof DayArray)[number]
 
-export type SemesterType = 'Spring' | 'Summer' | 'Fall' | 'Winter'
+export type SemesterType = number
 
 export type ColorType = 'Red' | 'Blue' | 'Green' | 'Purple' | 'Gray'
 

--- a/src/util/academicCalendar.ts
+++ b/src/util/academicCalendar.ts
@@ -2,7 +2,6 @@ import { match } from 'ts-pattern'
 
 import { GetCalendarYearlyResponse } from '@/api/types/calendar'
 import { Semester } from '@/types/timetable'
-import { numberToSemester } from '@/util/timetableUtil'
 
 /**
  * Semester에 해당하는 빈 학기 배열을 전달합니다
@@ -54,18 +53,18 @@ export const useAcademicSemester = () => {
 
   if (1 < month && month <= 7) {
     // 1학기
-    academicSemester.push({ year: `${year - 2}`, semester: numberToSemester[2], timetables: [] })
-    for (let i = 0; i < 4; i += 2) {
-      academicSemester.push({ year: `${year - 1}`, semester: numberToSemester[i], timetables: [] })
+    academicSemester.push({ year: `${year - 2}`, semester: 3, timetables: [] })
+    for (let i = 1; i <= 4; i += 2) {
+      academicSemester.push({ year: `${year - 1}`, semester: i, timetables: [] })
     }
-    academicSemester.push({ year: `${year}`, semester: numberToSemester[0], timetables: [] })
+    academicSemester.push({ year: `${year}`, semester: 1, timetables: [] })
   } else {
     // 2학기
-    for (let i = 0; i < 4; i += 2) {
-      academicSemester.push({ year: `${year - 1}`, semester: numberToSemester[i], timetables: [] })
+    for (let i = 1; i <= 4; i += 2) {
+      academicSemester.push({ year: `${year - 1}`, semester: i, timetables: [] })
     }
-    for (let i = 0; i < 4; i += 2) {
-      academicSemester.push({ year: `${year}`, semester: numberToSemester[i], timetables: [] })
+    for (let i = 1; i <= 4; i += 2) {
+      academicSemester.push({ year: `${year}`, semester: i, timetables: [] })
     }
   }
 

--- a/src/util/timetableUtil.ts
+++ b/src/util/timetableUtil.ts
@@ -1,26 +1,10 @@
 import html2canvas from 'html2canvas'
 
-import {
-  ColorType,
-  CourseType,
-  DayType,
-  GridType,
-  ScheduleType,
-  Semester,
-  SemesterType,
-  TimetableInfo,
-} from '@/types/timetable'
+import { ColorType, CourseType, DayType, GridType, ScheduleType, Semester, TimetableInfo } from '@/types/timetable'
 
 const dayToNumber: { [key in DayType]: number } = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6, Sun: 7 }
 
-export const numberToSemester: SemesterType[] = ['Spring', 'Summer', 'Fall', 'Winter']
-
-export const semesterToNumber: { [key in SemesterType]: number } = {
-  Spring: 1,
-  Summer: 2,
-  Fall: 3,
-  Winter: 4,
-}
+export const numberToSemester: string[] = ['_', 'Spring', 'Summer', 'Fall', 'Winter']
 
 export const ColorTypeArr: ColorType[] = ['Red', 'Blue', 'Green', 'Gray', 'Purple']
 
@@ -53,22 +37,22 @@ export const getCurSemester = () => {
   const year = KSTtoday.getFullYear()
   const month = KSTtoday.getMonth() + 1
 
-  let curSemester = 0
+  let semester = 0
 
   if (1 < month && month <= 6) {
     // 1학기
-    curSemester = 0
+    semester = 1
   } else if (6 < month && month <= 7) {
     // 여름학기
-    curSemester = 1
+    semester = 2
   } else if (7 < month && month <= 12) {
     // 2학기
-    curSemester = 2
+    semester = 3
   } else {
     // 겨울학기
-    curSemester = 3
+    semester = 4
   }
-  return { year, semester: numberToSemester[curSemester] }
+  return { year, semester }
 }
 
 /**
@@ -83,34 +67,34 @@ const calcSemester = (): Semester[] => {
 
   if (1 < month && month <= 6) {
     // 1학기
-    for (let i = 2; i < 4; i++) {
-      ret.push({ year: `${year - 1}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 3; semester <= 4; semester++) {
+      ret.push({ year: `${year - 1}`, semester, timetables: [] })
     }
-    for (let i = 0; i < 4; i++) {
-      ret.push({ year: `${year}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 1; semester <= 4; semester++) {
+      ret.push({ year: `${year}`, semester, timetables: [] })
     }
   } else if (6 < month && month <= 7) {
     // 여름학기
-    ret.push({ year: `${year - 1}`, semester: 'Winter', timetables: [] })
-    for (let i = 0; i < 4; i++) {
-      ret.push({ year: `${year}`, semester: numberToSemester[i], timetables: [] })
+    ret.push({ year: `${year - 1}`, semester: 4, timetables: [] })
+    for (let semester = 1; semester <= 4; semester++) {
+      ret.push({ year: `${year}`, semester, timetables: [] })
     }
-    ret.push({ year: `${year + 1}`, semester: 'Spring', timetables: [] })
+    ret.push({ year: `${year + 1}`, semester: 1, timetables: [] })
   } else if (7 < month && month <= 12) {
     // 2학기
-    for (let i = 0; i < 4; i++) {
-      ret.push({ year: `${year}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 1; semester <= 4; semester++) {
+      ret.push({ year: `${year}`, semester, timetables: [] })
     }
-    for (let i = 0; i < 2; i++) {
-      ret.push({ year: `${year + 1}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 1; semester <= 2; semester++) {
+      ret.push({ year: `${year + 1}`, semester, timetables: [] })
     }
   } else {
     // 겨울학기
-    for (let i = 1; i < 4; i++) {
-      ret.push({ year: `${year}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 2; semester <= 4; semester++) {
+      ret.push({ year: `${year}`, semester, timetables: [] })
     }
-    for (let i = 0; i < 3; i++) {
-      ret.push({ year: `${year + 1}`, semester: numberToSemester[i], timetables: [] })
+    for (let semester = 1; semester <= 3; semester++) {
+      ret.push({ year: `${year + 1}`, semester, timetables: [] })
     }
   }
   return ret
@@ -270,5 +254,5 @@ export const convertHtmlToImage = (ref: HTMLDivElement | null, fileName: string)
 }
 
 export const makeSemesterDropdownList = (semesterList: Semester[]) => {
-  return semesterList.map(semester => `${semester.year} ${semester.semester} semester`)
+  return semesterList.map(semester => `${semester.year} ${numberToSemester[semester.semester]} semester`)
 }

--- a/src/util/timetableUtil.ts
+++ b/src/util/timetableUtil.ts
@@ -15,6 +15,13 @@ const dayToNumber: { [key in DayType]: number } = { Mon: 1, Tue: 2, Wed: 3, Thu:
 
 export const numberToSemester: SemesterType[] = ['Spring', 'Summer', 'Fall', 'Winter']
 
+export const semesterToNumber: { [key in SemesterType]: number } = {
+  Spring: 1,
+  Summer: 2,
+  Fall: 3,
+  Winter: 4,
+}
+
 export const ColorTypeArr: ColorType[] = ['Red', 'Blue', 'Green', 'Gray', 'Purple']
 
 export const filterTypeMap = {

--- a/src/util/useCourseSearch.ts
+++ b/src/util/useCourseSearch.ts
@@ -12,7 +12,6 @@ import {
 } from '@/api/hooks/course'
 import { GetCourseResponse } from '@/api/types/course'
 import { SemesterType } from '@/types/timetable'
-import { semesterToNumber } from '@/util/timetableUtil'
 
 export interface useCourseSearchProps {
   queryKeyword: string
@@ -29,9 +28,8 @@ export const useCourseSearch = ({
   classification,
   filter,
   year,
-  semester: semesterString,
+  semester,
 }: useCourseSearchProps) => {
-  const semester = semesterToNumber[semesterString]
   return useInfiniteQuery({
     queryKey: ['courseSearchResult', queryKeyword, category, classification, filter, year, semester],
     queryFn: ({ pageParam: cursorId }) => {

--- a/src/util/useCourseSearch.ts
+++ b/src/util/useCourseSearch.ts
@@ -11,29 +11,41 @@ import {
   getMajor,
 } from '@/api/hooks/course'
 import { GetCourseResponse } from '@/api/types/course'
+import { SemesterType } from '@/types/timetable'
+import { semesterToNumber } from '@/util/timetableUtil'
 
 export interface useCourseSearchProps {
   queryKeyword: string
   category: 'All Class' | 'Major' | 'General Studies' | 'Academic Foundations'
   classification: string | null
   filter: 'course' | 'professor' | 'code'
+  year: string
+  semester: SemesterType
 }
 
-export const useCourseSearch = ({ queryKeyword, category, classification, filter }: useCourseSearchProps) => {
+export const useCourseSearch = ({
+  queryKeyword,
+  category,
+  classification,
+  filter,
+  year,
+  semester: semesterString,
+}: useCourseSearchProps) => {
+  const semester = semesterToNumber[semesterString]
   return useInfiniteQuery({
-    queryKey: ['courseSearchResult', queryKeyword, category, classification, filter],
+    queryKey: ['courseSearchResult', queryKeyword, category, classification, filter, year, semester],
     queryFn: ({ pageParam: cursorId }) => {
       if (category === 'Academic Foundations') {
         // 검색 미진행, 바로 띄워주기
-        return getInAcademicFoundation({ college: classification!, cursorId })
+        return getInAcademicFoundation({ college: classification!, cursorId, year, semester })
       }
 
       if (queryKeyword === '') {
         if (category === 'General Studies') {
-          return getGeneral({ cursorId })
+          return getGeneral({ cursorId, year, semester })
         }
         if (category === 'Major') {
-          return getMajor({ major: classification!, cursorId })
+          return getMajor({ major: classification!, cursorId, year, semester })
         }
         return new Promise<GetCourseResponse>(() => ({
           hasNextPage: false,
@@ -46,21 +58,21 @@ export const useCourseSearch = ({ queryKeyword, category, classification, filter
         // 강의명으로 검색
         if (category === 'General Studies') {
           // 교양 내 검색
-          return getByCourseNameInGeneral({ courseName: queryKeyword, cursorId })
+          return getByCourseNameInGeneral({ courseName: queryKeyword, cursorId, year, semester })
         }
         // 전공 내 검색
-        return getByCourseNameInMajor({ courseName: queryKeyword, major: classification!, cursorId })
+        return getByCourseNameInMajor({ courseName: queryKeyword, major: classification!, cursorId, year, semester })
       } else if (filter === 'professor') {
         // 교수명으로 검색
         if (category === 'General Studies') {
           // 교양 내 검색
-          return getByProfInGeneral({ professorName: queryKeyword, cursorId })
+          return getByProfInGeneral({ professorName: queryKeyword, cursorId, year, semester })
         }
         // 전공 내 검색
-        return getByProfInMajor({ professorName: queryKeyword, major: classification!, cursorId })
+        return getByProfInMajor({ professorName: queryKeyword, major: classification!, cursorId, year, semester })
       }
       // 학수번호로 검색, category는 무조건 All Class
-      return getByCourseCode({ courseCode: queryKeyword, cursorId })
+      return getByCourseCode({ courseCode: queryKeyword, cursorId, year, semester })
     },
     getNextPageParam: lastPage => {
       return lastPage?.nextCursorId === null ? undefined : lastPage?.nextCursorId


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- 백엔드 api에 year와 semester 정보가 추가되어, 현재 선택된 학기의 강의만 검색이 가능해요

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 선택된 학기의 강의만 제대로 검색 가능한지 (현재 dev 서버에 2024년 Spring 학기 강의 데이터만 있어요)

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
- Resolves #118 