### PR TITLE
refactor: 질문 게시판의 경우 댓글 숫자에 따라 수정, 삭제 가능 여부 판단

### DIFF
--- a/src/components/community/post/Post.tsx
+++ b/src/components/community/post/Post.tsx
@@ -4,7 +4,7 @@ import { isAxiosError } from 'axios'
 import { formatDistanceToNow } from 'date-fns'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Eye } from 'lucide-react'
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useDeletePost, useReportPost } from '@/api/hooks/community'
@@ -59,6 +59,12 @@ const Post = memo(() => {
     )
   }, [handleButtonClose, mutateReportPost, postAtomData.id])
 
+  const isPostEditable = useMemo(() => {
+    if (!postAtomData.isMyPost) return false
+    if (boardName !== 'question') return true
+    return postAtomData.comments.length <= 0
+  }, [boardName, postAtomData])
+
   return (
     <div className={postCard()}>
       <section
@@ -88,8 +94,8 @@ const Post = memo(() => {
           <UtilButton
             isComment={false}
             isMine={postAtomData.isMyPost}
-            isEditable={postAtomData.isMyPost && (boardName !== 'question' || postAtomData.comments.length < 0)}
-            isDeletable={postAtomData.isMyPost && (boardName !== 'question' || postAtomData.comments.length < 0)}
+            isEditable={isPostEditable}
+            isDeletable={isPostEditable}
             handleNavigation={handleNavigation}
             handleDelete={handleOpen}
             handleReport={handleOpen}


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

기존에 질문 게시판인 경우 댓글 숫자 판별하는 과정에서 0인 경우를 빼서 작동을 안 하고 있었어요.

> ```ts
> postAtomData.isMyPost && (boardName !== 'question' || postAtomData.comments.length < 0)
> ```

삼항 연산자가 눈에 쉽게 들어오지 않는 것 같아서 아예 변수를 뺐어요.
## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [x] 질문 게시판에서 댓글의 유무에 따라 수정 삭제 버튼이 보이는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
