### PR TITLE
fix(design): Lecture Search Lineheight 조정

### DIFF
--- a/src/components/timetable/LectureBottomSheet/AddClass/SearchLectureCard.tsx
+++ b/src/components/timetable/LectureBottomSheet/AddClass/SearchLectureCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@styled-system/css'
-import { ChevronRight, Dot } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import CookiesRate from '@/components/courseReview/CookiesRate'
@@ -12,7 +12,16 @@ interface SearchLectureCardProps {
 
 const SearchLectureCard = ({ data, addCourse }: SearchLectureCardProps) => {
   return (
-    <div className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'center', pr: 4, gap: 10 })}>
+    <div
+      className={css({
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        pr: 4,
+        gap: 10,
+        lineHeight: 1.2,
+      })}
+    >
       <div className={css({ display: 'flex', flexDir: 'column', gap: 2.5 })}>
         <div className={css({ display: 'flex', gap: 4, alignItems: 'center' })}>
           <span className={css({ fontSize: 16, fontWeight: 600, color: 'black.2', maxW: '430px', lineClamp: 2 })}>
@@ -33,11 +42,11 @@ const SearchLectureCard = ({ data, addCourse }: SearchLectureCardProps) => {
             Course plan <ChevronRight size={14} />
           </Link>
         </div>
-        <div className={css({ display: 'flex', alignItems: 'center', fontSize: 14, color: 'darkGray.1' })}>
+        <div className={css({ display: 'flex', alignItems: 'center', fontSize: 14, color: 'darkGray.1', gap: 2.5 })}>
           <span>{data.professorName}</span>
-          <Dot />
+          {'•'}
           <span>{data.details && data.details[0]?.classroom}</span>
-          <Dot />
+          {'•'}
           <span>{data.courseCode}</span>
         </div>
         <div

--- a/src/components/timetable/LectureBottomSheet/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/index.tsx
@@ -17,8 +17,11 @@ interface LectureBottomSheetProps {
   visible: boolean
 }
 const LectureBottomSheet = ({ timetableId, visible, year, semester }: LectureBottomSheetProps) => {
+  // TODO: useOverlay로 Refactor
   const [isOpen, setIsOpen] = useState(false)
   const [sheetState, setSheetState] = useState<'class' | 'schedule' | null>(null)
+
+  const openHeight = Math.min(window.innerHeight * 0.5, 520)
 
   const { mutate: postSchedule } = usePostSchedule()
 
@@ -73,7 +76,7 @@ const LectureBottomSheet = ({ timetableId, visible, year, semester }: LectureBot
         })}
         animate={isOpen ? 'open' : 'close'}
         initial={{ bottom: 0 }}
-        variants={{ open: { bottom: '400px' }, close: { bottom: 0 } }}
+        variants={{ open: { bottom: `${openHeight + 20}px` }, close: { bottom: 0 } }}
       >
         <Drawer isOpen={isOpen} sheetState={sheetState} handleDrawer={handleDrawer} visible={visible} />
         <div
@@ -81,7 +84,6 @@ const LectureBottomSheet = ({ timetableId, visible, year, semester }: LectureBot
             css({
               bgColor: '#FFFFFF80',
               w: '1200px',
-              h: '380px',
               backdropFilter: 'blur(25px)',
               rounded: 50,
               px: 26,
@@ -90,6 +92,7 @@ const LectureBottomSheet = ({ timetableId, visible, year, semester }: LectureBot
             }),
             shadow(),
           )}
+          style={{ height: openHeight }}
         >
           {sheetState === 'schedule' ? (
             <AddOnMyOwn submitHandler={addOnMyOwnHandler} />

--- a/src/components/timetable/SearchBox.tsx
+++ b/src/components/timetable/SearchBox.tsx
@@ -51,6 +51,7 @@ const SearchBox = ({ initialKeyword, placeholder, onSubmit, cssProps = {} }: Sea
           fontSize: 18,
           fontWeight: 500,
           flexGrow: 1,
+          lineHeight: 1.2,
           color: 'black.2',
           _placeholder: {
             color: 'lightGray.1',


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- Figma와 강의 검색 리스트 height가 미묘하게 다르던 스타일을 변경합니다
- Bottom Sheet height를 window 사이즈에 따라 다르게 표시될 수 있도록 하여 기존에 강의 두개(!!)밖에 표시 안되던 문제를 수정합니다
  - 다만 여전히 Sheet의 height가 정적이고, 전체 마진이 불필요하게 크며, 가독성이 떨어지는 등의 문제가 있어
  디자인 수정은 필요할 것 같습니다. 이 PR은 다음주의 테스트를 위한 긴급 조치라고 생각해주시면 될 것 같아요.
  - 필터를 제거하여 검색 경험을 개선하는 작업은 다른 PR로 올릴 예정이에요.

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 다른 모니터 사이즈에 따라 bottom sheet height가 괜찮게 표시되는지
- [ ] Figma의 디자인과 align되어 있는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
