### PR TITLE
feat: sidebar overlay 영역 배경 색 주입

### DIFF
--- a/src/components/ui/sheet/index.tsx
+++ b/src/components/ui/sheet/index.tsx
@@ -15,7 +15,13 @@ const SheetPortal = SheetPrimitive.Portal
 const SheetOverlay = forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({ className, ...props }, ref) => <SheetPrimitive.Overlay className={cx(css({}), className)} {...props} ref={ref} />)
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cx(css({ pos: 'fixed', inset: 0, bgColor: 'rgba(0,0,0,0.4)' }), className)}
+    {...props}
+    ref={ref}
+  />
+))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 type SheetContentProps = React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> &


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->
생각해보니 저희 사이드 바 햄버거 눌렀을 때 뒤에 배경영역에 overlay 색상이 없더라고요.? 그래서 추가했습니당

<img width="300" alt="스크린샷 2024-12-01 오후 4 14 33" src="https://github.com/user-attachments/assets/49758ee2-4191-4b96-9f42-72c610d29d54">

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ]

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
