### PR TITLE
fix: 카테고리 변경 시 검색어 초기화, 글자수가 충분하지 않은 경우 페이지가 터지는 버그

### DIFF
--- a/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
@@ -70,12 +70,12 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
       }
       if (toIndex === 0) {
         // All
-        search(prev => ({ ...prev, category: 'All Class', classification: null }))
+        search(() => ({ keyword: '', category: 'All Class', classification: null }))
         return
       }
       if (toIndex === 2) {
         // General
-        search(prev => ({ ...prev, category: 'General Studies', classification: null }))
+        search(() => ({ keyword: '', category: 'General Studies', classification: null }))
         return
       }
     },
@@ -85,7 +85,7 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
   const handleMajorBtn = useCallback(
     (classification: string) => {
       setIsModalOpen(false)
-      search(prev => ({ ...prev, category: categoryList[curCategory], classification }))
+      search(() => ({ keyword: '', category: categoryList[curCategory], classification }))
     },
     [curCategory, search],
   )
@@ -146,7 +146,10 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
               )}
             </div>
           </div>
-          <SearchBox onSubmit={handleSearchBoxOnSubmit} />
+          <SearchBox
+            onSubmit={handleSearchBoxOnSubmit}
+            resetKeys={[searchQuery.category, searchQuery.classification]}
+          />
         </div>
         {searchData.length ? (
           <div
@@ -165,7 +168,9 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
             <div ref={fetchNextRef} className={css({ height: 1 })} />
           </div>
         ) : searchQuery.category === 'All Class' && searchQuery.keyword.length === 0 ? (
-          <div className={SearchMessageStyle}>Enter keywords to search (e.g., course name, professor name, or course number)</div>
+          <div className={SearchMessageStyle}>
+            Enter keywords to search (e.g., course name, professor name, or course number)
+          </div>
         ) : (
           <div className={SearchMessageStyle}>There are no classes available for exchange students.</div>
         )}

--- a/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
+++ b/src/components/timetable/LectureBottomSheet/AddClass/index.tsx
@@ -1,13 +1,14 @@
 import { css } from '@styled-system/css'
-import { isAxiosError } from 'axios'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
 
 import { usePostCourse } from '@/api/hooks/timetable'
 import Dropdown from '@/components/timetable/Dropdown'
 import ClassSelectModal from '@/components/timetable/LectureBottomSheet/AddClass/ClassSelectModal'
 import SearchLectureCard from '@/components/timetable/LectureBottomSheet/AddClass/SearchLectureCard'
 import SearchBox from '@/components/timetable/SearchBox'
+import Toast from '@/components/ui/toast'
 import { SemesterType } from '@/types/timetable'
 import { useCourseSearch } from '@/util/hooks/useCourseSearch'
 import useIntersect from '@/util/hooks/useIntersect'
@@ -43,7 +44,6 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
     fetchNextPage,
     hasNextPage,
     isFetching,
-    error,
   } = useCourseSearch({ year, semester })
   const { mutate: postCourse } = usePostCourse()
 
@@ -91,8 +91,15 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
   )
 
   const handleSearchBoxOnSubmit = useCallback(
-    (queryKeyword: string) => search(prev => ({ ...prev, keyword: queryKeyword })),
-    [search],
+    (queryKeyword: string) => {
+      if ((queryKeyword.length === 0 && searchQuery.category !== 'All Class') || queryKeyword.length > 2)
+        // All Class가 아닌 Category에서 빈 글자 입력
+        // 또는 2글자 이상 검색
+        search(prev => ({ ...prev, keyword: queryKeyword }))
+      else
+        toast.custom(() => <Toast message="Please enter at least two letters for your search term." type="default" />)
+    },
+    [search, searchQuery.category],
   )
 
   const handleQuitModal = useCallback(() => {
@@ -141,9 +148,7 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
           </div>
           <SearchBox onSubmit={handleSearchBoxOnSubmit} />
         </div>
-        {isAxiosError(error) ? (
-          <div className={SearchMessageStyle}>{error.response?.data.message}</div>
-        ) : searchData.length ? (
+        {searchData.length ? (
           <div
             ref={scrollSectionRef}
             className={css({
@@ -159,6 +164,8 @@ const AddClass = ({ timetableId, year, semester }: AddClassProps) => {
             ))}
             <div ref={fetchNextRef} className={css({ height: 1 })} />
           </div>
+        ) : searchQuery.category === 'All Class' && searchQuery.keyword.length === 0 ? (
+          <div className={SearchMessageStyle}>Enter keywords to search (e.g., course name, professor name, or course number)</div>
         ) : (
           <div className={SearchMessageStyle}>There are no classes available for exchange students.</div>
         )}

--- a/src/components/timetable/SearchBox.tsx
+++ b/src/components/timetable/SearchBox.tsx
@@ -2,6 +2,8 @@ import { css, cva } from '@styled-system/css'
 import { Search } from 'lucide-react'
 import { CSSProperties, useState } from 'react'
 
+import { useDeepCompareEffect } from '@/util/hooks/useDeepCompare'
+
 const FormStyle = cva({
   base: {
     display: 'flex',
@@ -30,11 +32,20 @@ interface SearchBoxProps {
   placeholder?: string
   onSubmit: (queryKeyword: string) => void
   cssProps?: CSSProperties
+  // 배열 안에 담긴 값이 바뀌면 검색어를 초기화합니다
+  // @default []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resetKeys?: any[]
 }
 
-const SearchBox = ({ initialKeyword, placeholder, onSubmit, cssProps = {} }: SearchBoxProps) => {
+const SearchBox = ({ initialKeyword, placeholder, onSubmit, cssProps = {}, resetKeys = [] }: SearchBoxProps) => {
   const [inputKeyword, setInputKeyword] = useState(initialKeyword ?? '')
   const [isFocus, setIsFocus] = useState(false)
+
+  useDeepCompareEffect(() => {
+    setInputKeyword('')
+  }, resetKeys)
+
   return (
     <form
       className={FormStyle({ isFocus })}

--- a/src/util/hooks/useCourseSearch.ts
+++ b/src/util/hooks/useCourseSearch.ts
@@ -37,7 +37,7 @@ export const useCourseSearch = ({ year, semester }: CourseSearchProps) => {
     setSearchQuery(prev => queryFn(prev))
   }
 
-  const { data, fetchNextPage, hasNextPage, isFetching, error } = useSuspenseInfiniteQuery({
+  const { data, fetchNextPage, hasNextPage, isFetching } = useSuspenseInfiniteQuery({
     queryKey: ['courseSearchResult', year, semester, category, classification, keyword],
     queryFn: ({ pageParam: cursorId }) => {
       if (keyword.length) {
@@ -72,5 +72,5 @@ export const useCourseSearch = ({ year, semester }: CourseSearchProps) => {
     retry: false,
   })
 
-  return { searchQuery, data, search, fetchNextPage, hasNextPage, isFetching, error }
+  return { searchQuery, data, search, fetchNextPage, hasNextPage, isFetching }
 }


### PR DESCRIPTION
- 검색어 길이가 적절하지 않은 경우의 toast
- 초기 UX 라이팅 설정## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->
- 카테고리를 전환할 때 검색어가 초기화 돼요.
  - 기존에 구현했던 SearchBox를 외부에서 초기화시키기 위해 resetKeys 인자를 추가했어요
- 검색어를 2글자 이하로 입력한 경우 핸들링 없이 터지는 이슈를 해결하고, toast로 안내문구를 처리했어요.
- 처음 검색창에 랜딩했을 때 보여주는 안내문구를 추가했어요. (기존에는 `검색결과가 없습니다`로 보여지던 이슈)

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 카테고리 (또는 세부 학과)가 변경될 때 검색어가 잘 날아가는지 (input창 뿐 아니라 불러와지는 데이터도 적용되는지)
- [ ] 각종 상황 처리가 제대로 되는지
  - [ ] 검색어 글자수가 2글자 이하일 때 toast가 제대로 표시되는지
  - [ ] 검색 결과가 없을 때와 입력하지 않아 검색이 진행 불가한 경우(All Class && no keyword)가 다르게 안내되는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
