### PR TITLE
fix: Course Type 일정 요소 null type 추가

### DIFF
--- a/src/components/timetable/Friend/FriendTimetable.tsx
+++ b/src/components/timetable/Friend/FriendTimetable.tsx
@@ -3,9 +3,8 @@ import { forwardRef } from 'react'
 
 import { useGetFriendTimetable } from '@/api/hooks/friends'
 import LectureGrid from '@/components/timetable/Grid/LectureGrid'
-import { TimeCell } from '@/components/timetable/Grid/TimetableLayout'
 import { SemesterType } from '@/types/timetable'
-import { getWeeknTimeList, numberToSemester } from '@/util/timetableUtil'
+import { numberToSemester } from '@/util/timetableUtil'
 
 interface TimetableProps {
   user: string
@@ -15,7 +14,6 @@ interface TimetableProps {
 
 const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year, semester }, ref) => {
   const { data } = useGetFriendTimetable({ username: user, year, semester })
-  const { time, week } = getWeeknTimeList(data.courses, data.schedules)
 
   return (
     <div className={css({ w: '100%' })} ref={ref}>
@@ -43,7 +41,6 @@ const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year
               border: 'none',
               color: 'lightGray.1',
               fontWeight: 500,
-              fontSize: 18,
               outline: 'none',
               w: '70%',
               overflow: 'hidden',
@@ -55,44 +52,7 @@ const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year
           </div>
         </div>
       </div>
-      <div
-        className={css({
-          display: 'flex',
-          flexDir: 'row',
-          borderLeft: '1px solid {colors.lightGray.1}',
-          roundedBottom: 10,
-          bgColor: 'white',
-        })}
-      >
-        <div className={css({ display: 'flex', flexDir: 'column' })}>
-          {time.map((val, index) => {
-            return (
-              <div
-                key={index}
-                className={TimeCell({
-                  sidebar: true,
-                  header: index === 0,
-                  end: index === time.length - 1 ? 'leftEnd' : undefined,
-                })}
-              >
-                {val}
-              </div>
-            )
-          })}
-        </div>
-        <div className={css({ display: 'flex', flexDir: 'column', flex: 1 })}>
-          <div className={css({ display: 'flex', flexDir: 'row' })}>
-            {week.map((days, index) => {
-              return (
-                <div key={index} className={css({ flex: 1 }, TimeCell.raw({ header: true }))}>
-                  {days}
-                </div>
-              )
-            })}
-          </div>
-          <LectureGrid timetableData={data} weekCnt={week.length} timeCnt={time.length - 1} />
-        </div>
-      </div>
+      <LectureGrid timetableData={data} />
     </div>
   )
 })

--- a/src/components/timetable/Grid/LectureGrid.tsx
+++ b/src/components/timetable/Grid/LectureGrid.tsx
@@ -4,43 +4,85 @@ import { GetTimetableByTimetableIdResponse } from '@/api/types/timetable'
 import LectureSticker from '@/components/timetable/Grid/LectureSticker'
 import { TimeCell } from '@/components/timetable/Grid/TimetableLayout'
 import { COLOR_INFO } from '@/lib/constants/timetableColors'
-import { lectureDataPreprocess } from '@/util/timetableUtil'
+import { getWeeknTimeList, lectureDataPreprocess } from '@/util/timetableUtil'
 
 interface LectureGridProps {
   timetableId?: number
   timetableData: GetTimetableByTimetableIdResponse
-  weekCnt: number
-  timeCnt: number
   isMine?: boolean
 }
 
-const LectureGrid = ({ timetableId, timetableData, weekCnt, timeCnt, isMine = false }: LectureGridProps) => {
+const LectureGrid = ({ timetableId, timetableData, isMine = false }: LectureGridProps) => {
+  const { time, week } = getWeeknTimeList(timetableData.courses, timetableData.schedules)
+  const weekCnt = week.length
+  const timeCnt = time.length - 1
+
   const { lectureGrid } = lectureDataPreprocess(timetableData.courses, timetableData.schedules, weekCnt, timeCnt)
   const colorTheme = timetableData.color
   let lecCnt = 0
 
   return (
-    <div className={css({ display: 'grid' })} style={{ gridTemplateColumns: `repeat(${weekCnt}, 1fr)` }}>
-      {lectureGrid.map((lectures, gridInd) => {
-        return (
-          <div
-            key={gridInd}
-            className={TimeCell({ lectureGrid: true, end: gridInd === weekCnt * timeCnt - 1 ? 'rightEnd' : undefined })}
-          >
-            {lectures.map((lecture, lecInd) => {
-              return (
-                <LectureSticker
-                  key={lecInd}
-                  timetableId={timetableId}
-                  data={lecture}
-                  bgColor={COLOR_INFO[colorTheme]['rand'][lecCnt++ % COLOR_INFO[colorTheme]['rand'].length]}
-                  isMine={isMine}
-                />
-              )
-            })}
-          </div>
-        )
+    <div
+      className={css({
+        display: 'flex',
+        flexDir: 'row',
+        borderLeft: '1px solid {colors.lightGray.1}',
+        roundedBottom: 10,
+        bgColor: 'white',
       })}
+    >
+      <div className={css({ display: 'flex', flexDir: 'column' })}>
+        {time.map((val, index) => {
+          return (
+            <div
+              key={index}
+              className={TimeCell({
+                sidebar: true,
+                header: index === 0,
+                end: index === time.length - 1 ? 'leftEnd' : undefined,
+              })}
+            >
+              {val}
+            </div>
+          )
+        })}
+      </div>
+      <div className={css({ display: 'flex', flexDir: 'column', flex: 1 })}>
+        <div className={css({ display: 'flex', flexDir: 'row' })}>
+          {week.map((days, index) => {
+            return (
+              <div key={index} className={css({ flex: 1 }, TimeCell.raw({ header: true }))}>
+                {days}
+              </div>
+            )
+          })}
+        </div>
+        <div className={css({ display: 'grid' })} style={{ gridTemplateColumns: `repeat(${weekCnt}, 1fr)` }}>
+          {lectureGrid.map((lectures, gridInd) => {
+            return (
+              <div
+                key={gridInd}
+                className={TimeCell({
+                  lectureGrid: true,
+                  end: gridInd === weekCnt * timeCnt - 1 ? 'rightEnd' : undefined,
+                })}
+              >
+                {lectures.map((lecture, lecInd) => {
+                  return (
+                    <LectureSticker
+                      key={lecInd}
+                      timetableId={timetableId}
+                      data={lecture}
+                      bgColor={COLOR_INFO[colorTheme]['rand'][lecCnt++ % COLOR_INFO[colorTheme]['rand'].length]}
+                      isMine={isMine}
+                    />
+                  )
+                })}
+              </div>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/timetable/Grid/LectureGrid.tsx
+++ b/src/components/timetable/Grid/LectureGrid.tsx
@@ -15,13 +15,13 @@ interface LectureGridProps {
 }
 
 const LectureGrid = ({ timetableId, timetableData, weekCnt, timeCnt, isMine = false }: LectureGridProps) => {
-  const lecGrid = lectureDataPreprocess(timetableData.courses, timetableData.schedules, weekCnt, timeCnt)
+  const { lectureGrid } = lectureDataPreprocess(timetableData.courses, timetableData.schedules, weekCnt, timeCnt)
   const colorTheme = timetableData.color
   let lecCnt = 0
 
   return (
     <div className={css({ display: 'grid' })} style={{ gridTemplateColumns: `repeat(${weekCnt}, 1fr)` }}>
-      {lecGrid.map((lectures, gridInd) => {
+      {lectureGrid.map((lectures, gridInd) => {
         return (
           <div
             key={gridInd}

--- a/src/components/timetable/Grid/TimetableLayout.tsx
+++ b/src/components/timetable/Grid/TimetableLayout.tsx
@@ -6,7 +6,6 @@ import { useGetTimetable } from '@/api/hooks/timetable'
 import LectureGrid from '@/components/timetable/Grid/LectureGrid'
 import TimetableModal from '@/components/timetable/Modal/TimetableModal'
 import { GlobalModalStateType } from '@/types/timetable'
-import { getWeeknTimeList } from '@/util/timetableUtil'
 
 export const TimeCell = cva({
   base: {
@@ -72,52 +71,9 @@ const TimetableLayout = memo(
   }: TimetableLayoutProps) => {
     const { data } = useGetTimetable({ timetableId })
 
-    const { time, week } = getWeeknTimeList(data.courses, data.schedules)
-
     return (
-      <div
-        className={css({
-          display: 'flex',
-          flexDir: 'row',
-          borderLeft: '1px solid {colors.lightGray.1}',
-          roundedBottom: 10,
-          bgColor: 'white',
-        })}
-      >
-        <div className={css({ display: 'flex', flexDir: 'column' })}>
-          {time.map((val, index) => {
-            return (
-              <div
-                key={index}
-                className={TimeCell({
-                  sidebar: true,
-                  header: index === 0,
-                  end: index === time.length - 1 ? 'leftEnd' : undefined,
-                })}
-              >
-                {val}
-              </div>
-            )
-          })}
-        </div>
-        <div className={css({ display: 'flex', flexDir: 'column', flex: 1 })}>
-          <div className={css({ display: 'flex', flexDir: 'row' })}>
-            {week.map((days, index) => {
-              return (
-                <div key={index} className={css({ flex: 1 }, TimeCell.raw({ header: true }))}>
-                  {days}
-                </div>
-              )
-            })}
-          </div>
-          <LectureGrid
-            timetableId={timetableId}
-            timetableData={data}
-            weekCnt={week.length}
-            timeCnt={time.length - 1}
-            isMine={true}
-          />
-        </div>
+      <>
+        <LectureGrid timetableId={timetableId} timetableData={data} isMine={true} />
         {globalModalState &&
           createPortal(
             <div
@@ -152,7 +108,7 @@ const TimetableLayout = memo(
             </div>,
             document.body,
           )}
-      </div>
+      </>
     )
   },
 )

--- a/src/components/timetable/Modal/EditSchedule.tsx
+++ b/src/components/timetable/Modal/EditSchedule.tsx
@@ -40,7 +40,7 @@ const EditSchedule = ({ timetableId, data, closeScheduleModal }: EditSchedulePro
     >
       <AddOnMyOwn
         submitHandler={handleSubmit}
-        prevValue={{ title: data.title, day: data.day, location: data.location }}
+        prevValue={{ title: data.title, day: data.day, location: data.location ?? undefined }}
       />
     </div>
   )

--- a/src/types/timetable.ts
+++ b/src/types/timetable.ts
@@ -30,10 +30,10 @@ export interface CourseType {
   courseName: string
   courseCode: string
   syllabus: string
-  startTime: string
-  endTime: string
-  classroom: string
-  day: DayType
+  startTime: string | null
+  endTime: string | null
+  classroom: string | null
+  day: DayType | null
 }
 
 export interface ScheduleType {
@@ -45,15 +45,18 @@ export interface ScheduleType {
   scheduleDay: DayType
 }
 
-export interface GridType {
+export interface TimetableContentsType {
   scheduleType: 'Course' | 'Schedule'
   scheduleId: number
   title: string
-  startTime: string
-  endTime: string
-  location: string
-  day: DayType
+  location: string | null
   professorName?: string
   courseCode?: string
   syllabus?: string
+}
+
+export interface GridType extends TimetableContentsType {
+  startTime: string
+  endTime: string
+  day: DayType
 }

--- a/src/util/timetableUtil.ts
+++ b/src/util/timetableUtil.ts
@@ -1,6 +1,15 @@
 import html2canvas from 'html2canvas'
 
-import { ColorType, CourseType, DayType, GridType, ScheduleType, Semester, TimetableInfo } from '@/types/timetable'
+import {
+  ColorType,
+  CourseType,
+  DayType,
+  GridType,
+  ScheduleType,
+  Semester,
+  TimetableContentsType,
+  TimetableInfo,
+} from '@/types/timetable'
 
 const dayToNumber: { [key in DayType]: number } = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6, Sun: 7 }
 
@@ -140,23 +149,32 @@ export const lectureDataPreprocess = (
   for (let i = 0; i < cellCnt; i++) {
     lecGrid[i] = []
   }
+  const noScheduled: TimetableContentsType[] = []
 
   // 강의 데이터 Cell에 임베딩
   courseData.map(lecture => {
-    const index = weekCnt * getStartCell(lecture.startTime) + dayToNumber[lecture.day]
-    lecGrid[index - 1].push({
+    const timetableContents: TimetableContentsType = {
       scheduleType: 'Course',
       scheduleId: lecture.courseId,
       title: lecture.courseName,
       location: lecture.classroom,
-      day: lecture.day,
-      startTime: lecture.startTime,
-      endTime: lecture.endTime,
       courseCode: lecture.courseCode,
       professorName: lecture.professorName,
       syllabus: lecture.syllabus,
-    })
+    }
+    if (lecture.day !== null && lecture.startTime && lecture.endTime) {
+      const index = weekCnt * getStartCell(lecture.startTime) + dayToNumber[lecture.day]
+      lecGrid[index - 1].push({
+        ...timetableContents,
+        day: lecture.day,
+        startTime: lecture.startTime,
+        endTime: lecture.endTime,
+      })
+    } else {
+      noScheduled.push(timetableContents)
+    }
   })
+
   scheduleData.map(schedule => {
     const index = weekCnt * getStartCell(schedule.scheduleStartTime) + dayToNumber[schedule.scheduleDay]
     lecGrid[index - 1].push({
@@ -170,7 +188,7 @@ export const lectureDataPreprocess = (
     })
   })
 
-  return lecGrid
+  return { lectureGrid: lecGrid, noScheduled }
 }
 
 /**
@@ -182,9 +200,11 @@ export const getWeeknTimeList = (courseData: CourseType[], scheduleData: Schedul
   let lastDay = 5
 
   courseData.map(lec => {
-    lastTime = Math.max(lastTime, Number(lec.endTime.slice(0, 2)))
-    if (dayToNumber[lec.day] > lastDay) {
-      lastDay = dayToNumber[lec.day]
+    if (lec.day && lec.endTime) {
+      lastTime = Math.max(lastTime, Number(lec.endTime.slice(0, 2)))
+      if (dayToNumber[lec.day] > lastDay) {
+        lastDay = dayToNumber[lec.day]
+      }
     }
   })
   scheduleData.map(schedule => {


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- 시간이 지정되지 않은 강의에 대한 백엔드 api가 수정되어, startTime, endTime, classroom, day에 null 타입이 들어올 수 있게 되었어요.
- 현재는 프론트에서 이 항목의 null에 대해 대응되어있지 않아, 일정이 없는 강의(ex. COMPUTATIONAL THINKING)가 시간표에 있다면 터져버리는 문제가 발생해요.
- null 타입에 대해 유연하게 대처할 수 있도록 코드를 수정했어요. 일정이 없는 강의를 따로 보여주기 위해 `lectureDataPreprocess`에서 noScheduled 강의를 따로 배열로 반환하도록 구현했어요. 이 강의들을 보여주는 것은 다른 PR로 올릴 예정입니다.
- 타입을 고치다 `FriendTimetable.tsx`와 `TimetableLayout.tsx`에 중복된 코드가 많이 보여서 이를 두 컴포넌트에서 공통으로 쓰는`LectureGrid.tsx`에 합치는 작업을 진행했어요.

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ]

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

- #147 
