### PR TITLE
#154 / hotfix: Academic Schedule Page에서 실제 학기로 동기화해요

### DIFF
--- a/src/util/academicCalendar.ts
+++ b/src/util/academicCalendar.ts
@@ -30,7 +30,7 @@ export const useAcademicSemester = () => {
   const month = KSTtoday.getMonth() + 1
   const academicSemester: Semester[] = []
 
-  if (1 < month && month <= 7) {
+  if (1 <= month && month <= 7) {
     // 1학기
     academicSemester.push({ year: `${year - 2}`, semester: 3, timetables: [] })
     for (let i = 1; i <= 4; i += 2) {

--- a/src/util/timetableUtil.ts
+++ b/src/util/timetableUtil.ts
@@ -36,26 +36,25 @@ export const getStartTime = (time: string) => {
 }
 
 export const getCurSemester = () => {
-  const KSTtoday = new Date()
-  const year = KSTtoday.getFullYear()
-  const month = KSTtoday.getMonth() + 1
+  const todayKST = new Date()
+  const year = todayKST.getFullYear()
+  const month = todayKST.getMonth() + 1
 
-  let semester = 0
-
+  if (month === 1) {
+    // 겨울학기
+    return { year: year - 1, semester: 4 }
+  }
   if (1 < month && month <= 6) {
     // 1학기
-    semester = 1
-  } else if (6 < month && month <= 7) {
-    // 여름학기
-    semester = 2
-  } else if (7 < month && month <= 12) {
-    // 2학기
-    semester = 3
-  } else {
-    // 겨울학기
-    semester = 4
+    return { year, semester: 1 }
   }
-  return { year, semester }
+  if (6 < month && month <= 7) {
+    // 여름학기
+    return { year, semester: 2 }
+  }
+
+  // 2학기
+  return { year, semester: 3 }
 }
 
 /**


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->
- Academic Schedule Page에서 기본 세팅되어있는 Semester 선택 드롭다운의
현재 학기가 올바르게 반영되지 않던 문제를 수정해요
- 1월에 대한 처리가 제대로 되지 않던 이슈로, 저번 시간표 Semester 선택 드롭다운과 같은 원인이에요

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] Academic Schedule Page의 학기 시간표가 제대로 표시되는지 (일부만 보이는 2025년 데이터는 서버에서 곧 채워줄 예정이에요)

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
- Resolves #154 