### PR TITLE
#156 / Club 검색에서 두글자 이하 입력시 Toast로 처리해요

### DIFF
--- a/src/lib/messages/club.ts
+++ b/src/lib/messages/club.ts
@@ -1,0 +1,3 @@
+export const CLUB_SEARCH_MESSAGE = {
+  REQUIRED_LENGTH: 'Please enter at least 2 characters',
+}

--- a/src/lib/messages/common.ts
+++ b/src/lib/messages/common.ts
@@ -1,0 +1,3 @@
+export const USER_AUTH_MESSAGE = {
+  REQUIRE_LOGIN: 'Please sign in to use!',
+}

--- a/src/pages/ClubPage.tsx
+++ b/src/pages/ClubPage.tsx
@@ -13,6 +13,8 @@ import MetaTag from '@/components/MetaTag'
 import { Checkbox } from '@/components/ui/checkbox'
 import ClubModal from '@/components/ui/modal/ClubModal'
 import Toast from '@/components/ui/toast'
+import { CLUB_SEARCH_MESSAGE } from '@/lib/messages/club'
+import { USER_AUTH_MESSAGE } from '@/lib/messages/common'
 import { ClubInterface, ClubSearchParams } from '@/types/club'
 import { useAuth } from '@/util/auth/useAuth'
 import { useDeepCompareCallback } from '@/util/hooks/useDeepCompare'
@@ -44,7 +46,13 @@ const ClubPage = () => {
   )
 
   const handleSubmit = useDeepCompareCallback(
-    (inputKeyword: string) => setQuery({ ...query, keyword: inputKeyword.length ? inputKeyword : undefined }),
+    (inputKeyword: string) => {
+      if (inputKeyword.length < 2) {
+        toast.custom(() => <Toast message={CLUB_SEARCH_MESSAGE.REQUIRED_LENGTH} type="warning" />)
+        return
+      }
+      setQuery({ ...query, keyword: inputKeyword.length ? inputKeyword : undefined })
+    },
     [query],
   )
 
@@ -53,14 +61,14 @@ const ClubPage = () => {
   const handleLikeClick = useDeepCompareCallback(
     (clubId: number) => {
       if (isLogin) likeClub({ clubId, queryParams: requestQuery })
-      else toast.custom(() => <Toast message="Please sign in to use!" type="error" />)
+      else toast.custom(() => <Toast message={USER_AUTH_MESSAGE.REQUIRE_LOGIN} type="error" />)
     },
     [likeClub, query, isLogin],
   )
 
   const handleWishList = useDeepCompareCallback(() => {
     if (isLogin) setQuery({ ...query, filter: query.filter === 'like' ? undefined : 'like' })
-    else toast.custom(() => <Toast message="Please sign in to use!" type="error" />)
+    else toast.custom(() => <Toast message={USER_AUTH_MESSAGE.REQUIRE_LOGIN} type="error" />)
   }, [query, isLogin])
 
   const [selectedClub, setSelectedClub] = useState<ClubInterface | null>(null)


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->
- 클럽 페이지에서는 한글자 검색이 불가능하지만 기존에는 올바른 에러 처리 로직이 존재하지 않았어요.
- Submit Handler에 input 값이 2글자 이하가 들어오면 적절한 설명을 toast로 제공해요.
- Club Page에서 사용하는 에러 문구들을 `lib/messages` 디렉토리에서 관리해요.

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 에러 핸들링이 제대로 되는지

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
- Resolves #156 
- Related with #133 