### PR TITLE
fix(design): Timetable Red 색상 변경

### DIFF
--- a/src/lib/constants/timetableColors.ts
+++ b/src/lib/constants/timetableColors.ts
@@ -19,6 +19,6 @@ export const COLOR_INFO: { [key in ColorType]: { symbol: string; rand: string[] 
   },
   Red: {
     symbol: '#F17272',
-    rand: ['#E8B1ADCC', '#EC8A8ACC', '#F15151CC', '#C91717CC', '#711517CC'],
+    rand: ['#FF3535CC', '#F11E2DCC', '#C30010CC', '#F06B70CC', '#FFA4AECC'],
   },
 }


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- 정우님의 명을 받아 시간표 Red 색상을 수정했습니다
<img width="686" alt="Screenshot 2025-02-26 at 12 18 00 AM" src="https://github.com/user-attachments/assets/66e614b5-5cd1-4a6c-9ff4-246233a29a96" />

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ]

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
