### PR TITLE
feat: 게시판 카테고리 선택하는 탭을 구현해요. - 1

### DIFF
--- a/src/features/Community/CommunitySelectTab/index.tsx
+++ b/src/features/Community/CommunitySelectTab/index.tsx
@@ -1,0 +1,53 @@
+import * as s from './style.css'
+
+import { Button } from '@/ui/Button'
+import { useQueryParams } from '@/util/hooks/useQueryParams'
+
+const boardConfig = [
+  {
+    board: 'All',
+    boardId: 0,
+    displayText: 'All',
+  },
+  {
+    board: 'CommunityBoard',
+    boardId: 1,
+    displayText: 'Community Board',
+  },
+  {
+    board: 'QuestionBoard',
+    boardId: 2,
+    displayText: 'Question Board',
+  },
+  {
+    board: 'InformationBoard',
+    boardId: 3,
+    displayText: 'Information Board',
+  },
+] as const
+
+type BoardType = (typeof boardConfig)[number]['board']
+type BoardQueryParam = {
+  board: BoardType
+  boardId: number
+}
+
+const CommunitySelectTab = () => {
+  const [queryParam, setQueryParam] = useQueryParams<BoardQueryParam>()
+
+  return (
+    <div className={s.Wrapper}>
+      {boardConfig.map(board => (
+        <Button
+          variant="default"
+          isActive={queryParam.board === board.board}
+          onClick={() => setQueryParam({ board: board.board, boardId: board.boardId })}
+        >
+          {board.displayText}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+export default CommunitySelectTab

--- a/src/features/Community/CommunitySelectTab/style.css.ts
+++ b/src/features/Community/CommunitySelectTab/style.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css'
+
+import { f } from '@/style'
+
+export const Wrapper = style([
+  f.flex,
+  f.justifyBetween,
+  f.alignCenter,
+  f.background.lightGray2,
+  { width: '44.5625rem', padding: '0.625rem', borderRadius: '6px' },
+])

--- a/src/lib/router/router.tsx
+++ b/src/lib/router/router.tsx
@@ -22,6 +22,7 @@ import {
   WriteReviewPage,
 } from '@/lib/router/lazy-route'
 import ProtectedRoutes from '@/lib/router/ProtectedRoutes'
+import CommunityAllPage from '@/pages/Community/All'
 import HomePage from '@/pages/Home'
 import LandingPage from '@/pages/LandingPage'
 import Login from '@/pages/LoginPage'
@@ -67,6 +68,10 @@ const routes: RouteObject[] = [
           {
             path: 'community',
             element: <MainCommunityPage />,
+          },
+          {
+            path: 'community/all',
+            element: <CommunityAllPage />,
           },
           {
             path: 'community/action/:type/post/:boardName',

--- a/src/pages/Community/All/index.tsx
+++ b/src/pages/Community/All/index.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+import * as s from './style.css'
+
+import { LoadingScreen } from '@/components/ui/spinner'
+import CommunitySelectTab from '@/features/Community/CommunitySelectTab'
+
+const CommunityAllPage = () => {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <main className={s.Wrapper}>
+        <CommunitySelectTab />
+      </main>
+    </Suspense>
+  )
+}
+
+export default CommunityAllPage

--- a/src/pages/Community/All/style.css.ts
+++ b/src/pages/Community/All/style.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+import { f } from '@/style'
+
+export const Wrapper = style([f.flex, f.directionColumn, { marginTop: '2.5rem' }])

--- a/src/ui/Button/index.tsx
+++ b/src/ui/Button/index.tsx
@@ -10,14 +10,15 @@ type Props = {
   asChild?: boolean
   style?: React.CSSProperties
   variant?: s.ButtonVariants
+  isActive?: boolean
 } & React.ButtonHTMLAttributes<HTMLButtonElement>
 
 export const Button = forwardRef<HTMLButtonElement, Props>(
-  ({ suffixIcon, prefixIcon, children, asChild, onClick, variant = 'default', ...props }, ref) => {
+  ({ suffixIcon, prefixIcon, children, asChild, onClick, variant = 'default', isActive, ...props }, ref) => {
     const Component = asChild ? Slot : 'button'
 
     return (
-      <Component ref={ref} onClick={onClick} {...props} className={s.Button[variant]}>
+      <Component ref={ref} onClick={onClick} {...props} className={s.Button[variant]} data-active={isActive}>
         <div data-part="content">
           {prefixIcon && <span data-part="prefix">{prefixIcon}</span>}
           <span data-part="text">{children}</span>

--- a/src/ui/Button/style.css.ts
+++ b/src/ui/Button/style.css.ts
@@ -22,7 +22,7 @@ export const Button = styleVariants({
   default: [
     Base,
     {
-      ':hover': {
+      '&:not([data-active="true"]):hover': {
         background: vars.color.lightGray1,
         color: vars.color.white,
       },
@@ -32,6 +32,10 @@ export const Button = styleVariants({
       },
       ':focus': {
         boxShadow: vars.shadow.p25,
+      },
+      '&[data-active="true"]': {
+        background: vars.color.red2,
+        color: vars.color.white,
       },
     },
   ],


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->
우선 게시판 카테고리 선택을 하는 탭을 구현했어요. 기존의 버튼 컴포넌트를 활용했어요.

<img width="782" alt="스크린샷 2025-03-02 오전 12 46 45" src="https://github.com/user-attachments/assets/e14bbd50-07f9-4c07-9488-370d89fd1ebf" />

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ]

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
