### PR TITLE
[#220] 수정된 Timetable DTO에 대응해요

### DIFF
--- a/src/api/hooks/friends.ts
+++ b/src/api/hooks/friends.ts
@@ -10,7 +10,7 @@ import {
   PatchFriendshipRequestRequest,
   PostFriendshipRequest,
 } from '@/api/types/friends'
-import { GetFriendTimetableResponse } from '@/api/types/timetable'
+import { GetTimetableByTimetableIdResponse } from '@/api/types/timetable'
 import { apiInterface } from '@/util/axios/custom-axios'
 
 const getFriendList = async ({ keyword }: GetFriendListRequest) => {
@@ -141,7 +141,7 @@ export const useDeleteFriendship = () => {
 }
 
 const getFriendTimetable = async (props: GetFriendTimetableRequest) => {
-  const response = await apiInterface.get<GetFriendTimetableResponse>(`/friendship/friend-timetable`, {
+  const response = await apiInterface.get<GetTimetableByTimetableIdResponse>(`/friendship/friend-timetable`, {
     params: props,
   })
   return response.data

--- a/src/api/hooks/schedule.ts
+++ b/src/api/hooks/schedule.ts
@@ -30,10 +30,10 @@ export const usePostSchedule = () => {
       queryClient.setQueryData<GetTimetableByTimetableIdResponse>(
         ['timetable', String(response.timetableId)],
         prevData => {
-          if (prevData !== undefined) {
+          if (prevData !== undefined && prevData.timetable !== null) {
             return {
               ...prevData,
-              schedules: prevData.schedules.concat([
+              schedules: prevData.timetable.schedules.concat([
                 {
                   location: response.location,
                   scheduleDay: response.day,
@@ -100,10 +100,10 @@ export const usePatchSchedule = () => {
       queryClient.setQueryData<GetTimetableByTimetableIdResponse>(
         ['timetable', String(response.timetableId)],
         prevData => {
-          if (prevData !== undefined) {
+          if (prevData !== undefined && prevData.timetable !== null) {
             return {
               ...prevData,
-              schedules: prevData.schedules.map(schedule => {
+              schedules: prevData.timetable.schedules.map(schedule => {
                 if (schedule.scheduleId === response.id) {
                   return {
                     location: response.location,

--- a/src/api/hooks/schedule.ts
+++ b/src/api/hooks/schedule.ts
@@ -32,17 +32,19 @@ export const usePostSchedule = () => {
         prevData => {
           if (prevData !== undefined && prevData.timetable !== null) {
             return {
-              ...prevData,
-              schedules: prevData.timetable.schedules.concat([
-                {
-                  location: response.location,
-                  scheduleDay: response.day,
-                  scheduleEndTime: response.endTime,
-                  scheduleId: response.id,
-                  scheduleStartTime: response.startTime,
-                  scheduleTitle: response.title,
-                },
-              ]),
+              timetable: {
+                ...prevData.timetable,
+                schedules: prevData.timetable.schedules.concat([
+                  {
+                    location: response.location,
+                    scheduleDay: response.day,
+                    scheduleEndTime: response.endTime,
+                    scheduleId: response.id,
+                    scheduleStartTime: response.startTime,
+                    scheduleTitle: response.title,
+                  },
+                ]),
+              },
             }
           }
         },
@@ -102,20 +104,22 @@ export const usePatchSchedule = () => {
         prevData => {
           if (prevData !== undefined && prevData.timetable !== null) {
             return {
-              ...prevData,
-              schedules: prevData.timetable.schedules.map(schedule => {
-                if (schedule.scheduleId === response.id) {
-                  return {
-                    location: response.location,
-                    scheduleDay: response.day,
-                    scheduleEndTime: response.endTime,
-                    scheduleId: response.id,
-                    scheduleStartTime: response.startTime,
-                    scheduleTitle: response.title,
+              timetable: {
+                ...prevData.timetable,
+                schedules: prevData.timetable.schedules.map(schedule => {
+                  if (schedule.scheduleId === response.id) {
+                    return {
+                      location: response.location,
+                      scheduleDay: response.day,
+                      scheduleEndTime: response.endTime,
+                      scheduleId: response.id,
+                      scheduleStartTime: response.startTime,
+                      scheduleTitle: response.title,
+                    }
                   }
-                }
-                return schedule
-              }),
+                  return schedule
+                }),
+              },
             }
           }
         },

--- a/src/api/hooks/timetable.ts
+++ b/src/api/hooks/timetable.ts
@@ -31,9 +31,12 @@ export const useGetUserTimetableList = () => {
 }
 
 const INITIAL_TIMETABLE: GetTimetableByTimetableIdResponse = {
-  courses: [],
-  schedules: [],
-  color: 'Red',
+  timetable: {
+    timetableName: '',
+    courses: [],
+    schedules: [],
+    color: 'Red',
+  },
 }
 
 const getTimetableByID = async ({ timetableId }: GetTimetableByTimetableIdRequest) => {
@@ -184,10 +187,10 @@ export const useDeleteCourse = () => {
     onSuccess: (response, request) => {
       if (response.deleted) {
         queryClient.setQueryData<GetTimetableByTimetableIdResponse>(['timetable', request.timetableId], prevData => {
-          if (prevData !== undefined) {
+          if (prevData !== undefined && prevData.timetable !== null) {
             return {
               ...prevData,
-              courses: prevData.courses.filter(course => {
+              courses: prevData.timetable.courses.filter(course => {
                 return course.courseId !== request.courseId
               }),
             }

--- a/src/api/hooks/timetable.ts
+++ b/src/api/hooks/timetable.ts
@@ -189,10 +189,12 @@ export const useDeleteCourse = () => {
         queryClient.setQueryData<GetTimetableByTimetableIdResponse>(['timetable', request.timetableId], prevData => {
           if (prevData !== undefined && prevData.timetable !== null) {
             return {
-              ...prevData,
-              courses: prevData.timetable.courses.filter(course => {
-                return course.courseId !== request.courseId
-              }),
+              timetable: {
+                ...prevData.timetable,
+                courses: prevData.timetable.courses.filter(course => {
+                  return course.courseId !== request.courseId
+                }),
+              },
             }
           }
         })

--- a/src/api/types/timetable.ts
+++ b/src/api/types/timetable.ts
@@ -1,17 +1,11 @@
-import { ColorType, CourseType, ScheduleType, SemesterType, TimetableInfo } from '@/types/timetable'
+import { ColorType, SemesterType, TimetableInfo, TimetableInterface } from '@/types/timetable'
 
 export interface GetTimetableByTimetableIdRequest {
   timetableId: number
 }
 
 export interface GetTimetableByTimetableIdResponse {
-  courses: CourseType[]
-  schedules: ScheduleType[]
-  color: ColorType
-}
-
-export interface GetFriendTimetableResponse extends GetTimetableByTimetableIdResponse {
-  timetableName: string
+  timetable: TimetableInterface | null
 }
 
 export type GetTimetableByUserIdResponse = TimetableInfo[]

--- a/src/components/timetable/Friend/FriendTimetable.tsx
+++ b/src/components/timetable/Friend/FriendTimetable.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from 'react'
 
 import { useGetFriendTimetable } from '@/api/hooks/friends'
 import LectureGrid from '@/components/timetable/Grid/LectureGrid'
+import NullTable from '@/components/timetable/Grid/NullTable'
 import { SemesterType } from '@/types/timetable'
 import { numberToSemester } from '@/util/timetableUtil'
 
@@ -13,7 +14,11 @@ interface TimetableProps {
 }
 
 const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year, semester }, ref) => {
-  const { data } = useGetFriendTimetable({ username: user, year, semester })
+  const {
+    data: { timetable: timetableData },
+  } = useGetFriendTimetable({ username: user, year, semester })
+
+  if (timetableData === null) return <NullTable />
 
   return (
     <div className={css({ w: '100%' })} ref={ref}>
@@ -48,11 +53,11 @@ const FriendTimetable = forwardRef<HTMLDivElement, TimetableProps>(({ user, year
               textOverflow: 'ellipsis',
             })}
           >
-            {data.timetableName}
+            {timetableData.timetableName}
           </div>
         </div>
       </div>
-      <LectureGrid timetableData={data} />
+      <LectureGrid timetableData={timetableData} />
     </div>
   )
 })

--- a/src/components/timetable/Grid/LectureGrid.tsx
+++ b/src/components/timetable/Grid/LectureGrid.tsx
@@ -1,14 +1,14 @@
 import { css } from '@styled-system/css'
 import { useMemo } from 'react'
 
-import { GetTimetableByTimetableIdResponse } from '@/api/types/timetable'
 import NoScheduledArea from '@/components/timetable/Grid/NoScheduledArea'
 import ScheduledArea from '@/components/timetable/Grid/ScheduledArea'
+import { TimetableInterface } from '@/types/timetable'
 import { getWeeknTimeList, lectureDataPreprocess } from '@/util/timetableUtil'
 
 interface LectureGridProps {
   timetableId?: number // 친구 시간표의 경우 undefined
-  timetableData: GetTimetableByTimetableIdResponse
+  timetableData: TimetableInterface
   isMine?: boolean
 }
 

--- a/src/components/timetable/Grid/NullTable/index.tsx
+++ b/src/components/timetable/Grid/NullTable/index.tsx
@@ -1,0 +1,15 @@
+import * as s from './style.css'
+
+import { Typography } from '@/ui/Typography'
+
+const NullTable = () => {
+  return (
+    <div className={s.Wrapper}>
+      <Typography typography="heading2SB" mobileTypography="headingSB" color="darkGray1">
+        Timetable hasn't been created yet!
+      </Typography>
+    </div>
+  )
+}
+
+export default NullTable

--- a/src/components/timetable/Grid/NullTable/style.css.ts
+++ b/src/components/timetable/Grid/NullTable/style.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css'
+
+import { f } from '@/style'
+import { vars } from '@/theme/theme.css'
+
+export const Wrapper = style([
+  f.wFull,
+  f.hFull,
+  f.flexCenter,
+  {
+    height: '30rem',
+    backgroundColor: vars.color.bgGray,
+    borderRadius: '10px',
+    border: '1px solid',
+    borderColor: vars.color.lightGray1,
+  },
+])

--- a/src/components/timetable/Grid/TimetableLayout.tsx
+++ b/src/components/timetable/Grid/TimetableLayout.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 
 import { useGetTimetable } from '@/api/hooks/timetable'
 import LectureGrid from '@/components/timetable/Grid/LectureGrid'
+import NullTable from '@/components/timetable/Grid/NullTable'
 import TimetableModal from '@/components/timetable/Modal/TimetableModal'
 import { GlobalModalStateType } from '@/types/timetable'
 
@@ -10,7 +11,6 @@ interface TimetableLayoutProps {
   globalModalState: GlobalModalStateType
   closeTimetableModal: () => void
   deleteTimetableHandler: (timetableId: number) => void
-  timetableName: string
 }
 
 /**
@@ -18,25 +18,23 @@ interface TimetableLayoutProps {
  * 시간표 제목 헤더를 제외한 실제 그리드를 구성합니다
  */
 const TimetableLayout = memo(
-  ({
-    timetableId,
-    globalModalState,
-    closeTimetableModal,
-    deleteTimetableHandler,
-    timetableName,
-  }: TimetableLayoutProps) => {
-    const { data } = useGetTimetable({ timetableId })
+  ({ timetableId, globalModalState, closeTimetableModal, deleteTimetableHandler }: TimetableLayoutProps) => {
+    const {
+      data: { timetable: timetableData },
+    } = useGetTimetable({ timetableId })
+
+    if (timetableData === null) return <NullTable />
 
     return (
       <>
-        <LectureGrid timetableId={timetableId} timetableData={data} isMine={true} />
+        <LectureGrid timetableId={timetableId} timetableData={timetableData} isMine={true} />
         <TimetableModal
           modalType={globalModalState}
           closeModal={closeTimetableModal}
           deleteTimetableHandler={deleteTimetableHandler}
           timetableId={timetableId}
-          timetableName={timetableName}
-          curColor={data.color}
+          timetableName={timetableData.timetableName}
+          curColor={timetableData.color}
         />
       </>
     )

--- a/src/components/timetable/index.tsx
+++ b/src/components/timetable/index.tsx
@@ -152,7 +152,6 @@ const Timetable = forwardRef<HTMLDivElement, TimetableProps>(
           globalModalState={globalModalState}
           closeTimetableModal={closeTimetableModal}
           deleteTimetableHandler={deleteTimetableHandler}
-          timetableName={timetableName}
         />
       </div>
     )

--- a/src/types/timetable.ts
+++ b/src/types/timetable.ts
@@ -60,3 +60,10 @@ export interface GridType extends TimetableContentsType {
   endTime: string
   day: DayType
 }
+
+export interface TimetableInterface {
+  timetableName: string
+  courses: CourseType[]
+  schedules: ScheduleType[]
+  color: ColorType
+}


### PR DESCRIPTION
## 📌 내용

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

- 서버에서 주는 Timetable의 DTO가 변경되어, 관련 데이터를 사용하는 페이지에서 에러가 발생하고 있습니다.
- 본 PR은 Dev가 터지는 것에 대한 핫픽스 대응이에요. 제대로 시간표가 보여지는지, 예기치 못한 버그가 있는지 위주로 확인해주세요!
- 프론트에 지정된 interface를 변경하여 에러에 대응하고, `timetable: null`로 들어오는 사항에 대해서는 다음과 같은 UI를 표시해요.
<img width="1036" alt="Screenshot 2025-03-27 at 11 27 11 PM" src="https://github.com/user-attachments/assets/e86895e1-e775-471c-b927-256ffe0246ae" />

- 현재 타임테이블 관련 컴포넌트들은 #168 , #29 를 통해 전면 리팩토링중입니다.
따라서 이 PR에 포함된 코드들도 추후 아키텍처가 정리되어 리팩토링 될 예정이에요.

## ☑️ 체크 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ]

## ❗ Related Issues

<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->
- Resolves #220 
